### PR TITLE
fix: non thread-safe Builder methods need exclusive borrow

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -79,7 +79,7 @@ impl Builder {
     /// # Panics
     /// Panics if the provided `filter` regular expression is longer than [`u32::MAX`] bytes.
     #[must_use]
-    pub fn config_paths_count(&self, filter: Option<&'_ str>) -> u32 {
+    pub fn config_paths_count(&mut self, filter: Option<&'_ str>) -> u32 {
         let filter = filter.unwrap_or("");
         let filter_len = u32::try_from(filter.len()).expect("filter is too long");
         unsafe {
@@ -98,7 +98,7 @@ impl Builder {
     /// # Panics
     /// Panics if the provided `filter` regular expression is longer than [`u32::MAX`] bytes.
     #[must_use]
-    pub fn config_paths(&self, filter: Option<&'_ str>) -> WafOwned<WafArray> {
+    pub fn config_paths(&mut self, filter: Option<&'_ str>) -> WafOwned<WafArray> {
         let mut res = WafOwned::<WafArray>::default();
         let filter = filter.unwrap_or("");
         let filter_len = u32::try_from(filter.len()).expect("filter is too long");
@@ -118,7 +118,7 @@ impl Builder {
     /// Returns [None] if the builder fails to create a new [Handle], meaning the current
     /// configuration contains no active instructions (no rules nor processors are available).
     #[must_use]
-    pub fn build(&self) -> Option<Handle> {
+    pub fn build(&mut self) -> Option<Handle> {
         let raw = unsafe { crate::bindings::ddwaf_builder_build_instance(self.raw) };
         if raw.is_null() {
             return None;

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -5,7 +5,7 @@ use libddwaf::{
 
 #[test]
 pub fn blank_config() {
-    let builder = Builder::new(&Config::default()).expect("builder should be created");
+    let mut builder = Builder::new(&Config::default()).expect("builder should be created");
     // Not adding any rules, so we can't get a handle...
     assert!(builder.build().is_none());
 }


### PR DESCRIPTION
The `config_paths`, `config_paths_count` and `build` methods of the `Builder` type have backing implementations that are not thread-safe, and hence must operate on an exclusive borrow instead of allowing shared borrows as they previously did.