### PR TITLE
chore: allow build with only FIPS-compliant dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,18 @@ serde = { version = "1.0", optional = true }
 [build-dependencies]
 bindgen = "0.72"
 flate2 = "1.1"
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "http2", "rustls-tls-native-roots-no-provider"] }
 tar = "0.4"
+# Following is to ensure FIPS compliance is possible.
+hyper-rustls = { version = "*", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "*", default-features = false, features= ["aws-lc-rs"] }
 
 [dev-dependencies]
 serde_json = "1.0"
 
 [features]
 default = ["serde"]
+fips = ["hyper-rustls/fips", "rustls/fips"]
 serde = ["dep:serde"]
 
 [lints.rust]


### PR DESCRIPTION
Tweak the use of `reqwest` so that a build with not FIPS-incompatible dependencies is possible by enabling the `fips` feature.