### PR TITLE
fix: `libddwaf-sys` dependency fails to resolve from outside

### DIFF
--- a/crates/libddwaf/Cargo.toml
+++ b/crates/libddwaf/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/DataDog/libddwaf-rust"
 
 [dependencies]
-libddwaf-sys = { path = "../libddwaf-sys", default-features = false }
+libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The path dependency is not effectively used by `cargo` unless the build is local to it.