### PR TITLE
chore: introduce RUSTC_WRAPPER for Alpine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,15 +1,2 @@
 [env]
 MACOSX_DEPLOYMENT_TARGET = '12.7'
-
-# bindgen uses `clang-sys` which by default dynamically opens `libclang.so`;
-# however this is not supported on Alpine Linux (the usual musl target).
-# Enabling the `static` feature of `bindgen`/`clang-sys` creates additional
-# build requirements (`libLLVM.a`), which Alpine's `llvm-static` does not
-# provide (it has its content presented as many `libLLVM*.a` files). Disabling
-# statically linking to the C runtime alleviates this issue, but can result in
-# `proc-macro` not being usable; which notably causes doc tests to fail with
-# a big linker error.
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]

--- a/.cargo/musl.rustc-wrapper
+++ b/.cargo/musl.rustc-wrapper
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+if [ "${CARGO_CRATE_NAME}" != 'build_script_build' ]; then
+    exec "$@"
+fi
+
+if [ "${CARGO_PKG_NAME}" != 'libddwaf-sys' ]; then
+    exec "$@"
+fi
+
+exec "$@" "-Ctarget-feature=-crt-static"

--- a/.cargo/musl.rustc-wrapper
+++ b/.cargo/musl.rustc-wrapper
@@ -1,5 +1,14 @@
 #!/usr/bin/env sh
 
+###
+# This wrapper should be set to `RUSTC_WRAPPER` when building the `libddwaf-sys`
+# crate on musl-based platforms (e.g, Alpine), so that the build-script for it
+# is compiled with `-Ctarget-feature=-crt-static`, so that `bindgen` can
+# dynamically load `libclang` (musl static targets are unable to dynamically
+# load code), while continuing to build the surrounding code with the static
+# C runtime (ensuring it can be fully static).
+###
+
 if [ "${CARGO_CRATE_NAME}" != 'build_script_build' ]; then
     exec "$@"
 fi

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -14,6 +14,7 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     --mount=type=cache,target=/root/.cargo/registry                             \
     cd /workspace/src &&                                                        \
     if [ "$(uname -m)" = "x86_64" ]; then                                       \
+        clang --print-libgcc-file-name &&                                       \
         export RUSTFLAGS="-Cdefault-linker-libraries";                          \
     fi &&                                                                       \
     RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -14,6 +14,6 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     --mount=type=cache,target=/root/.cargo/registry                             \
     cd /workspace/src &&                                                        \
     if [ "$(uname -m)" = "x86_64" ]; then                                       \
-        export RUSTFLAGS="-Clinker=clang -Cdefault-linker-libraries";           \
+        export RUSTFLAGS="-Cdefault-linker-libraries";                          \
     fi &&                                                                       \
     RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.22.0
 
-RUN apk add --no-cache curl make build-base clang-libclang musl-dev
+RUN apk add --no-cache curl make build-base clang clang-libclang musl-dev
 
 RUN curl https://sh.rustup.rs -sSf |                                            \
     sh -s -- --profile minimal                                                  \
@@ -15,6 +15,6 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     cd /workspace/src &&                                                        \
     if [ "$(uname -m)" = "x86_64" ]; then                                       \
         clang --print-libgcc-file-name &&                                       \
-        export RUSTFLAGS="-Cdefault-linker-libraries";                          \
+        export RUSTFLAGS="-Clinker=clang -Cdefault-linker-libraries";           \
     fi &&                                                                       \
     RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.22.0
 
-RUN apk add --no-cache curl make build-base clang-libclang
+RUN apk add --no-cache curl make build-base clang-libclang musl-dev
 
 RUN curl https://sh.rustup.rs -sSf |                                            \
     sh -s -- --profile minimal                                                  \

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -12,4 +12,5 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     --mount=type=cache,target=/workspace/src/target,rw                          \
     --mount=type=cache,target=/root/.cargo/git                                  \
     --mount=type=cache,target=/root/.cargo/registry                             \
-    cd /workspace/src && make test
+    cd /workspace/src &&                                                        \
+    RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -13,4 +13,7 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     --mount=type=cache,target=/root/.cargo/git                                  \
     --mount=type=cache,target=/root/.cargo/registry                             \
     cd /workspace/src &&                                                        \
+    if [ "$(uname -m)" = "x86_64" ]; then                                       \
+        export RUSTFLAGS="-Clinker=clang -Cdefault-linker-libraries";           \
+    fi &&                                                                       \
     RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -28,7 +28,7 @@ fn main() {
         // Check each forbidden dependency
         for dependency in &forbidden_dependencies {
             if let Err(error_msg) = check_forbidden_dependency(dependency) {
-                println!("cargo:error={error_msg}");
+                println!("cargo::error={error_msg}");
                 exit(-1);
             }
         }
@@ -171,11 +171,11 @@ fn main() {
 
     // Add library search path and link directive
     println!(
-        "cargo:rustc-link-search=native={}",
+        "cargo::rustc-link-search=native={}",
         lib_dir.to_str().unwrap()
     );
     if !feature_dynamic {
-        println!("cargo:rustc-link-lib=static=ddwaf");
+        println!("cargo::rustc-link-lib=static=ddwaf");
     }
 
     // macOS has libc++ only as a dynamic library, so it's not bundled in libddwaf.a/.so.
@@ -185,14 +185,14 @@ fn main() {
     // if we want to disable this in final binaries, see maybe
     // https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+        "cargo::rustc-link-arg=-Wl,-rpath,{}",
         lib_dir.to_str().unwrap()
     );
 
     #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    println!("cargo::rustc-link-arg=-Wl,-rpath,$ORIGIN");
     #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+    println!("cargo::rustc-link-arg=-Wl,-rpath,@loader_path");
 
     // Generate bindings with bindgen
     let builder = bindgen::Builder::default()
@@ -237,7 +237,7 @@ fn main() {
         .write_to_file(bindings_out_path)
         .expect("Failed to write bindings.rs");
 
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=build.rs");
 }
 
 /// Checks if a specific dependency is present in the dependency tree when FIPS is enabled.


### PR DESCRIPTION
This allows building the build-script of `libddwaf-sys` with the `-Ctarget-feature=-crt-static` flag on musl targets so that it can have bindgen dynamically load LLVM, while still building a fully static binary with the rest.

Related: https://github.com/DataDog/datadog-lambda-extension/issues/858