### PR TITLE
Upgrade to v2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -138,15 +138,37 @@ jobs:
                     path: target/coverage/html
                     if-no-files-found: error
 
+    leak-check:
+        name: Leak Check
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+            - name: Cache
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+              with:
+                  path: |-
+                    ~/.cargo/bin/
+                    ~/.cargo/git/db/
+                    ~/.cargo/registry/cache/
+                    ~/.cargo/registry/index/
+                    ~/.rustup/downloads/
+                    ~/.rustup/update-hashes/
+                    target/
+                  key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ github.ref_name }}-${{ hashFiles('.cargo/config.toml', '**/Cargo.toml') }}
+                  restore-keys: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ github.ref_name }}-
+            - name: Leak Check
+              run: make leak_check
+
     complete:
         name: Complete
-        needs: [linters, tests, docker-tests, coverage]
+        needs: [linters, tests, docker-tests, coverage, leak-check]
         if: '!cancelled()'
         runs-on: ubuntu-latest
         steps:
             - name: Success
-              if: needs.linters.result == 'success' && needs.tests.result == 'success' && needs.docker-tests.result == 'success' && needs.coverage.result == 'success'
+              if: needs.linters.result == 'success' && needs.tests.result == 'success' && needs.docker-tests.result == 'success' && needs.coverage.result == 'success' && needs.leak-check.result == 'success'
               run: echo 'Success!'
             - name: Failure
-              if: needs.linters.result != 'success' || needs.tests.result != 'success' || needs.docker-tests.result != 'success' || needs.coverage.result != 'success'
+              if: needs.linters.result != 'success' || needs.tests.result != 'success' || needs.docker-tests.result != 'success' || needs.coverage.result != 'success' || needs.leak-check.result != 'success'
               run: echo 'Failure!' && exit 1

--- a/.github/workflows/pull_request/Dockerfile.alpine
+++ b/.github/workflows/pull_request/Dockerfile.alpine
@@ -1,6 +1,6 @@
 FROM alpine:3.22.0
 
-RUN apk add --no-cache curl make build-base clang clang-libclang musl-dev
+RUN apk add --no-cache curl make build-base clang clang-libclang musl-dev compiler-rt
 
 RUN curl https://sh.rustup.rs -sSf |                                            \
     sh -s -- --profile minimal                                                  \
@@ -8,13 +8,14 @@ RUN curl https://sh.rustup.rs -sSf |                                            
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+ENV RUSTC_LOG=rustc_codegen_ssa::back::link=debug
+
 RUN --mount=type=bind,source=.,target=/workspace/src,rw                         \
     --mount=type=cache,target=/workspace/src/target,rw                          \
     --mount=type=cache,target=/root/.cargo/git                                  \
     --mount=type=cache,target=/root/.cargo/registry                             \
     cd /workspace/src &&                                                        \
-    if [ "$(uname -m)" = "x86_64" ]; then                                       \
-        clang --print-libgcc-file-name &&                                       \
-        export RUSTFLAGS="-Clinker=clang -Cdefault-linker-libraries";           \
-    fi &&                                                                       \
-    RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test
+    clang_rt_lib="clang_rt.builtins-$(uname -m)" &&                             \
+    clang_rt_lib_dir=$(dirname $(clang --print-file-name="lib${clang_rt_lib}.a")) && \
+    export RUSTFLAGS="-Clinker=clang -Clink-arg=-L${clang_rt_lib_dir} -Clink-arg=-l${clang_rt_lib}" && \
+    RUSTDOCFLAGS="$RUSTFLAGS" RUSTC_WRAPPER=/workspace/src/.cargo/musl.rustc-wrapper make test

--- a/.github/workflows/pull_request/Dockerfile.lambda-al2
+++ b/.github/workflows/pull_request/Dockerfile.lambda-al2
@@ -10,7 +10,8 @@ RUN curl https://sh.rustup.rs -sSf |                                            
 
 ENV PATH="/root/.cargo/bin:$PATH"
 
-ENV RUSTFLAGS="-Clinker=clang -Clink-arg=-L/usr/lib64/clang/11.1.0/lib"
+ENV RUSTC_LOG=rustc_codegen_ssa::back::link=debug
+
 RUN --mount=type=bind,source=.,target=/workspace/src,rw                                             \
     --mount=type=cache,target=/workspace/src/target,rw                                              \
     --mount=type=cache,target=/root/.cargo/git                                                      \
@@ -18,5 +19,5 @@ RUN --mount=type=bind,source=.,target=/workspace/src,rw                         
     cd /workspace/src &&                                                                            \
     clang_rt_lib="clang_rt.builtins-$(uname -m)" &&                                                 \
     clang_rt_lib_dir=$(dirname $(clang --print-file-name="lib${clang_rt_lib}.a")) &&                \
-    export RUSTFLAGS="${RUSTFLAGS} -Clinker=clang -L${clang_rt_lib_dir} -l${clang_rt_lib}" &&       \
-    make test
+    export RUSTFLAGS="-Clinker=clang -Clink-arg=-L${clang_rt_lib_dir} -Clink-arg=-l${clang_rt_lib}" && \
+    RUSTDOCFLAGS="$RUSTFLAGS" make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to libddwaf-rust
+
+## Build Dependencies
+
+Before contributing, ensure you have the required dependencies installed. See the [README](README.md) for details on:
+- C standard library headers (for `aws-lc-rs`)
+- Clang/libclang (for `bindgen`)
+
+## Makefile Targets
+
+The project provides several Makefile targets for development:
+
+### `make check`
+
+Runs the complete quality assurance suite: tests, miri, clippy, and format
+checking. This is the recommended target to run before submitting a pull
+request.
+
+### `make test`
+
+Runs the full test suite:
+```bash
+cargo test --all-targets
+cargo test --doc
+```
+
+### `make miri`
+
+Runs tests under [Miri](https://github.com/rust-lang/miri), a tool for detecting
+undefined behavior in Rust code. Uses the nightly toolchain.
+
+Miri cannot interpret foreign function interface (FFI) calls, which means tests
+that call into the native `libddwaf` C library cannot run under Miri.
+
+Tests that use FFI must be excluded from Miri runs. There are two patterns used
+in this codebase:
+
+**1. File-level exclusion** - For test files that exclusively test FFI
+functionality:
+```rust
+#![cfg(not(miri))]
+```
+    Place this at the top of the test file. This is used for integration tests
+    in files like `tests/context.rs`, `tests/handle.rs`, `tests/config.rs`, etc.
+
+**2. Function-level exclusion** - For individual tests within files that have a
+mix of pure Rust and FFI tests:
+```rust
+#[test]
+#[cfg(not(miri))]
+fn test_that_uses_ffi() {
+    // ...
+}
+```
+
+Some tests are also excluded from Miri because they take too long to run under
+the interpreter (Miri is significantly slower than native execution):
+```rust
+#[test]
+#[cfg(not(miri))] // takes too long
+fn test_large_array_operations() {
+   // ...
+}
+```
+
+### `make coverage`
+
+Generates code coverage reports using `llvm-cov`. Requires the nightly
+toolchain. Outputs:
+- LCOV report to `target/lcov.info`
+- HTML report to `target/coverage/`
+- Fails if line coverage drops below 85%
+
+### `make clippy`
+
+Runs Clippy lints on all targets:
+```bash
+cargo clippy --all-targets
+```
+
+### `make format_check`
+
+Checks code formatting without modifying files:
+```bash
+cargo fmt -- --check
+```
+
+To fix formatting issues, run `cargo fmt` directly.
+
+
+## Using `LIBDDWAF_PREFIX`
+
+By default, the build script downloads the `libddwaf` C library from GitHub
+releases. You can override this behavior by setting the `LIBDDWAF_PREFIX`
+environment variable to point to a local installation:
+
+```bash
+export LIBDDWAF_PREFIX=/path/to/libddwaf
+cargo build
+```
+
+The prefix directory must contain:
+- `include/ddwaf.h` - The header file for bindgen
+- `lib/libddwaf.a` or `lib/libddwaf.so`/`lib/libddwaf.dylib` - The library file
+
+This is useful for:
+- Testing against a custom build of libddwaf
+- Development when working on libddwaf itself
+- Environments where downloading from GitHub is not possible
+
+Note: Some tests that verify version matching will be skipped when
+`LIBDDWAF_PREFIX` is set, since the installed version may differ from the
+expected crate version.
+
+## C++ Runtime Linking
+
+The `libddwaf` C library is written in C++ and requires linking against the C++
+standard library in certain scenarios.
+
+On macOS, `libc++` is only available as a dynamic library, so the build script
+automatically links against it:
+```
+cargo::rustc-link-lib=c++
+```
+
+On Linux, linking against `libstdc++` is controlled via the `link-stdcxx` feature:
+
+```bash
+# Enable static linking to libstdc++
+cargo build --features link-stdcxx
+```
+
+When enabled, the build script adds:
+```
+cargo::rustc-link-lib=static=stdc++
+```
+
+This is only needed when linking against a dynamic `libddwaf.so` that wasn't
+statically compiled against a C++ runtime or using a `libbdwaf.a` that doesn't
+include the C++ runtime inside. This isn't the case with official libddwaf
+releases.
+
+## Crate Features
+
+For details on available features (`serde`, `dynamic`, `dynamic-link`, `fips`,
+`link-stdcxx`), see the [README](README.md).
+
+# vim: set ts sw=4 ts=4 tw=80:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [workspace]
-resolver = "3"
+resolver = "2"
 members = ["crates/*"]
 default-members = ["crates/*"]
 
 [workspace.package]
 authors = ["DataDog, Inc. <support@datadoghq.com>"]
 version = "1.28.1"
-edition = "2024"
+edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/libddwaf-rust"
 categories = ["api-bindings", "security"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 
 [workspace.package]
 authors = ["DataDog, Inc. <support@datadoghq.com>"]
-version = "1.28.1"
+version = "2.0.0-alpha0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/DataDog/libddwaf-rust"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 .PHONY: test
 
 miri:
-	PATH="/home/glopes/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin:$$PATH" cargo miri test --lib --tests
+	cargo +nightly miri test --lib --tests
 .PHONY: miri
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ format_check:
 	cargo fmt -- --check
 .PHONY: format_check
 
+leak_check:
+	RUSTFLAGS="-Zsanitizer=leak" cargo +nightly test --all-targets --target-dir target/leak_check
+.PHONY: leak_check
+
 Cargo.lock: Cargo.toml
 	cargo check
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
-check: test clippy format_check
+check: test miri clippy format_check
 .PHONY: check
 
 test:
 	cargo test --all-targets
 .PHONY: test
+
+miri:
+	PATH="/home/glopes/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin:$$PATH" cargo miri test --lib --tests
+.PHONY: miri
 
 coverage:
 	cargo +nightly llvm-cov test --all-targets --branch --quiet --lcov --output-path=target/lcov.info \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ format_check:
 .PHONY: format_check
 
 leak_check:
-	RUSTFLAGS="-Zsanitizer=leak" cargo +nightly test --all-targets --target-dir target/leak_check
+	RUSTFLAGS="-Zsanitizer=leak" LSAN_OPTIONS="symbolize=1:external_symbolizer_path=/usr/bin/addr2line" cargo +nightly test --all-targets --target-dir target/leak_check
 .PHONY: leak_check
 
 Cargo.lock: Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ check: test miri clippy format_check
 
 test:
 	cargo test --all-targets
+	cargo test --doc
 .PHONY: test
 
 miri:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ useful to reduce the stat-up overhead in case the `libddwaf` features are not al
 features are opt-in); but it increases the size of the final binary & decreases overall performance of using those
 functions (due to their being dynamically dispatched).
 
-### `dynamic-link``
+### `dynamic-link`
 Mutually exclusive with `dynamic`. Plain dynamic linking against the shared `libddwaf` library. The library (called
 `libddwaf.so` on Linux) must be available at runtime through the usual mechanisms of the dynamic linker.
+
+### `link-stdcxx`
+Used to control linking against libstdc++ in Linux; needed under some limited circumstances such as with non-official
+builds of libddwaf. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ The `dynamic` feature (disabled by default) causes the native `libddwaf` library
 useful to reduce the stat-up overhead in case the `libddwaf` features are not always used (such as if the security
 features are opt-in); but it increases the size of the final binary & decreases overall performance of using those
 functions (due to their being dynamically dispatched).
+
+### `dynamic-link``
+Mutually exclusive with `dynamic`. Plain dynamic linking against the shared `libddwaf` library. The library (called
+`libddwaf.so` on Linux) must be available at runtime through the usual mechanisms of the dynamic linker.

--- a/crates/libddwaf-sys/Cargo.toml
+++ b/crates/libddwaf-sys/Cargo.toml
@@ -33,6 +33,7 @@ zstd = "0.13"
 default = []
 fips = ["hyper-rustls/fips", "rustls/fips"]
 dynamic = ["lazy_static", "libloading", "tempfile", "tracing", "zstd"]
+link-stdcxx = []
 
 [lints]
 workspace = true

--- a/crates/libddwaf-sys/Cargo.toml
+++ b/crates/libddwaf-sys/Cargo.toml
@@ -32,7 +32,10 @@ zstd = "0.13"
 [features]
 default = []
 fips = ["hyper-rustls/fips", "rustls/fips"]
+# Embeds a compressed libddwaf.so and extracts it to a temporary file at runtime, then loads it with libloading/dlopen
 dynamic = ["lazy_static", "libloading", "tempfile", "tracing", "zstd"]
+# Links to libddwaf.so dynamically via the system dynamic linker and rpath (simpler, requires library at runtime)
+dynamic-link = []
 link-stdcxx = []
 
 [lints]

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -63,13 +63,16 @@ fn main() {
     }
 
     // macOS has libc++ only as a dynamic library, so it's not bundled in libddwaf.a/.so.
-    #[cfg(target_os = "macos")]
-    println!("cargo::rustc-link-lib=c++");
-
     // Linux needs to link against libstdc++ for C++ standard library symbols
     // This can be controlled via the `link-stdcxx` feature
-    #[cfg(all(target_os = "linux", feature = "link-stdcxx"))]
-    println!("cargo::rustc-link-lib=stdc++");
+    // Note: We check the TARGET environment variable, not cfg!(target_os), because
+    // cfg! evaluates for the build script's host, not the cross-compilation target
+    let target = env::var("TARGET").expect("TARGET environment variable not set");
+    if target.contains("apple") || target.contains("darwin") {
+        println!("cargo::rustc-link-lib=c++");
+    } else if target.contains("linux") && env::var("CARGO_FEATURE_LINK_STDCXX").is_ok() {
+        println!("cargo::rustc-link-lib=static=stdc++");
+    }
 
     // if we want to disable this in final binaries, see maybe
     // https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufRead};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, exit};
 
 use flate2::read::GzDecoder;
@@ -43,6 +43,117 @@ fn main() {
     let version =
         env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION environment variable not set");
 
+    // Check if the `dynamic` feature is enabled.
+    let feature_dynamic = env::var("CARGO_FEATURE_DYNAMIC").is_ok();
+
+    // Check if a custom libddwaf installation prefix is provided
+    let (include_dir, lib_dir, soname) = if let Some(prefix) = env::var_os("LIBDDWAF_PREFIX") {
+        from_installed_libddwaf(&prefix)
+    } else {
+        from_github_release(&version, &out_dir)
+    };
+
+    // Add library search path and link directive
+    println!(
+        "cargo::rustc-link-search=native={}",
+        lib_dir.to_str().unwrap()
+    );
+    if !feature_dynamic {
+        println!("cargo::rustc-link-lib=static=ddwaf");
+    }
+
+    // macOS has libc++ only as a dynamic library, so it's not bundled in libddwaf.a/.so.
+    #[cfg(target_os = "macos")]
+    println!("cargo::rustc-link-lib=c++");
+
+    // Linux needs to link against libstdc++ for C++ standard library symbols
+    // This can be controlled via the `link-stdcxx` feature
+    #[cfg(all(target_os = "linux", feature = "link-stdcxx"))]
+    println!("cargo::rustc-link-lib=stdc++");
+
+    // if we want to disable this in final binaries, see maybe
+    // https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
+    println!(
+        "cargo::rustc-link-arg=-Wl,-rpath,{}",
+        lib_dir.to_str().unwrap()
+    );
+
+    #[cfg(target_os = "linux")]
+    println!("cargo::rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    #[cfg(target_os = "macos")]
+    println!("cargo::rustc-link-arg=-Wl,-rpath,@loader_path");
+
+    // Generate bindings with bindgen
+    let builder = bindgen::Builder::default()
+        .header(include_dir.join("ddwaf.h").to_str().unwrap())
+        .clang_arg(format!("-I{}", include_dir.to_str().unwrap()))
+        .default_visibility(bindgen::FieldVisibilityKind::Public)
+        .derive_default(true)
+        .prepend_enum_name(false)
+        // Specifically allow-list supported/useful functions to avoid bloat.
+        .allowlist_function("^ddwaf_.*");
+    let builder = if feature_dynamic {
+        let filename = out_dir.join(format!("{soname}.zst"));
+        let zstd_file = File::create(&filename).expect("failed to create zstd file");
+        let mut zstd = zstd::Encoder::new(zstd_file, 22).expect("failed to create zstd encoder");
+
+        let mut so = File::open(lib_dir.join(soname)).expect("failed to open shared object file");
+        io::copy(&mut so, &mut zstd).expect("failed to write compressed shared object file");
+        zstd.finish().expect("failed to finish zstd compression");
+
+        println!(
+            "cargo::rustc-env=LIBDDWAF_SHARED_OBJECT.zst={}",
+            filename.display()
+        );
+
+        builder
+            .dynamic_library_name("ddwaf")
+            .dynamic_link_require_all(true)
+    } else {
+        builder
+    };
+    let bindings = builder.generate().expect("Failed to generate bindings");
+
+    // Write the bindings to the output directory
+    let bindings_out_path = out_dir.join("bindings.rs");
+    bindings
+        .write_to_file(bindings_out_path)
+        .expect("Failed to write bindings.rs");
+
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-env-changed=LIBDDWAF_PREFIX");
+}
+
+fn from_installed_libddwaf(prefix: impl AsRef<OsStr>) -> (PathBuf, PathBuf, &'static str) {
+    println!(
+        "cargo::warning=Using libddwaf installation from prefix: {:?}",
+        prefix.as_ref()
+    );
+    let prefix_path = PathBuf::from(prefix.as_ref());
+    let include_dir = prefix_path.join("include");
+    let lib_dir = prefix_path.join("lib");
+
+    // Validate that the directories exist
+    if !include_dir.exists() {
+        panic!("Include directory not found at {}", include_dir.display());
+    }
+    if !lib_dir.exists() {
+        panic!("Library directory not found at {}", lib_dir.display());
+    }
+
+    // Determine the shared library name based on the target platform
+    let soname = if cfg!(target_os = "macos") {
+        "libddwaf.dylib"
+    } else {
+        "libddwaf.so"
+    };
+
+    (include_dir, lib_dir, soname)
+}
+
+fn from_github_release(version: &str, out_dir: &Path) -> (PathBuf, PathBuf, &'static str) {
+    // Download and extract libddwaf from GitHub releases
+
     // Target triple for the current build
     let target = env::var("TARGET").expect("TARGET environment variable not set");
 
@@ -51,10 +162,6 @@ fn main() {
     let include_dir = download_dir.join("include");
     let lib_dir = download_dir.join("lib");
 
-    // Check if the `dynamic` feature is enabled.
-    let feature_dynamic = env::var("CARGO_FEATURE_DYNAMIC").is_ok();
-
-    // Download the archive
     let (archive, soname, is_override) = {
         // Base URL for downloading the library
         let base_url = "https://github.com/DataDog/libddwaf/releases/download";
@@ -169,75 +276,7 @@ fn main() {
         panic!("Failed to extract include and lib directories");
     }
 
-    // Add library search path and link directive
-    println!(
-        "cargo::rustc-link-search=native={}",
-        lib_dir.to_str().unwrap()
-    );
-    if !feature_dynamic {
-        println!("cargo::rustc-link-lib=static=ddwaf");
-    }
-
-    // macOS has libc++ only as a dynamic library, so it's not bundled in libddwaf.a/.so.
-    #[cfg(target_os = "macos")]
-    println!("cargo::rustc-link-lib=c++");
-
-    // if we want to disable this in final binaries, see maybe
-    // https://github.com/rust-lang/cargo/issues/4789#issuecomment-2308131243
-    println!(
-        "cargo::rustc-link-arg=-Wl,-rpath,{}",
-        lib_dir.to_str().unwrap()
-    );
-
-    #[cfg(target_os = "linux")]
-    println!("cargo::rustc-link-arg=-Wl,-rpath,$ORIGIN");
-    #[cfg(target_os = "macos")]
-    println!("cargo::rustc-link-arg=-Wl,-rpath,@loader_path");
-
-    // Generate bindings with bindgen
-    let builder = bindgen::Builder::default()
-        .header(include_dir.join("ddwaf.h").to_str().unwrap())
-        .clang_arg(format!("-I{}", include_dir.to_str().unwrap()))
-        .default_visibility(bindgen::FieldVisibilityKind::Public)
-        .derive_default(true)
-        .prepend_enum_name(false)
-        // Specifically allow-list supported/useful functions to avoid bloat.
-        .allowlist_function("^ddwaf_(get_version|set_log_cb)$")
-        .allowlist_function("^ddwaf_(destroy|known_(addresses|actions))$")
-        .allowlist_function("^ddwaf_(context_(init|destroy)|run)$")
-        .allowlist_function("^ddwaf_builder_(init|add_or_update_config|remove_config|build_instance|get_config_paths|destroy)$")
-        .allowlist_function(
-            "^ddwaf_object_(array|bool|float|free|from_json|invalid|map|null|signed|stringl|unsigned)$",
-        );
-    let builder = if feature_dynamic {
-        let filename = download_dir.join(format!("{soname}.zst"));
-        let zstd_file = File::create(&filename).expect("failed to create zstd file");
-        let mut zstd = zstd::Encoder::new(zstd_file, 22).expect("failed to create zstd encoder");
-
-        let mut so = File::open(lib_dir.join(soname)).expect("failed to open shared object file");
-        io::copy(&mut so, &mut zstd).expect("failed to write compressed shared object file");
-        zstd.finish().expect("failed to finish zstd compression");
-
-        println!(
-            "cargo::rustc-env=LIBDDWAF_SHARED_OBJECT.zst={}",
-            filename.display()
-        );
-
-        builder
-            .dynamic_library_name("ddwaf")
-            .dynamic_link_require_all(true)
-    } else {
-        builder
-    };
-    let bindings = builder.generate().expect("Failed to generate bindings");
-
-    // Write the bindings to the output directory
-    let bindings_out_path = out_dir.join("bindings.rs");
-    bindings
-        .write_to_file(bindings_out_path)
-        .expect("Failed to write bindings.rs");
-
-    println!("cargo::rerun-if-changed=build.rs");
+    (include_dir, lib_dir, soname)
 }
 
 /// Checks if a specific dependency is present in the dependency tree when FIPS is enabled.

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -12,6 +12,13 @@ use tar::Archive;
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
+    let feature_dynamic = env::var("CARGO_FEATURE_DYNAMIC").is_ok();
+    let feature_dynamic_link = env::var("CARGO_FEATURE_DYNAMIC_LINK").is_ok();
+
+    if feature_dynamic && feature_dynamic_link {
+        panic!("The `dynamic` and `dynamic-link` features are mutually exclusive. Please enable only one.");
+    }
+
     if cfg!(target_env = "musl") && cfg!(target_feature = "crt-static") {
         println!(
             "cargo::warning=The crt-static target feature must be disabled when building on musl targets."
@@ -43,9 +50,6 @@ fn main() {
     let version =
         env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION environment variable not set");
 
-    // Check if the `dynamic` feature is enabled.
-    let feature_dynamic = env::var("CARGO_FEATURE_DYNAMIC").is_ok();
-
     // Check if a custom libddwaf installation prefix is provided
     let (include_dir, lib_dir, soname) = if let Some(prefix) = env::var_os("LIBDDWAF_PREFIX") {
         from_installed_libddwaf(&prefix)
@@ -58,7 +62,9 @@ fn main() {
         "cargo::rustc-link-search=native={}",
         lib_dir.to_str().unwrap()
     );
-    if !feature_dynamic {
+    if feature_dynamic_link {
+        println!("cargo::rustc-link-lib=dylib=ddwaf");
+    } else if !feature_dynamic {
         println!("cargo::rustc-link-lib=static=ddwaf");
     }
 

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -58,6 +58,7 @@ fn main() {
     } else {
         from_github_release(&version, &out_dir)
     };
+    println!("cargo::rerun-if-env-changed=LIBDDWAF_PREFIX");
 
     // Add library search path and link directive
     println!(
@@ -132,7 +133,6 @@ fn main() {
         .expect("Failed to write bindings.rs");
 
     println!("cargo::rerun-if-changed=build.rs");
-    println!("cargo::rerun-if-env-changed=LIBDDWAF_PREFIX");
 }
 
 fn from_installed_libddwaf(prefix: impl AsRef<OsStr>) -> (PathBuf, PathBuf, &'static str) {

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -16,7 +16,9 @@ fn main() {
     let feature_dynamic_link = env::var("CARGO_FEATURE_DYNAMIC_LINK").is_ok();
 
     if feature_dynamic && feature_dynamic_link {
-        panic!("The `dynamic` and `dynamic-link` features are mutually exclusive. Please enable only one.");
+        panic!(
+            "The `dynamic` and `dynamic-link` features are mutually exclusive. Please enable only one."
+        );
     }
 
     if cfg!(target_env = "musl") && cfg!(target_feature = "crt-static") {

--- a/crates/libddwaf-sys/build.rs
+++ b/crates/libddwaf-sys/build.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
-use std::process::{Command, exit};
+use std::process::{exit, Command};
 
 use flate2::read::GzDecoder;
 use reqwest::blocking::get;

--- a/crates/libddwaf-sys/src/dylib.rs
+++ b/crates/libddwaf-sys/src/dylib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::missing_safety_doc)]
 
-use std::io::{Write, copy};
+use std::io::{copy, Write};
 
 use crate::*;
 

--- a/crates/libddwaf-sys/src/dylib.rs
+++ b/crates/libddwaf-sys/src/dylib.rs
@@ -91,29 +91,68 @@ macro_rules! reexport {
 
 // Please keep this list alphanumerically sorted for convenience.
 reexport! {
+    pub unsafe fn ddwaf_allocator_alloc(alloc: ddwaf_allocator, bytes: usize, alignment: usize) -> *mut ::std::os::raw::c_void { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_allocator_destroy(alloc: ddwaf_allocator) {}
+    pub unsafe fn ddwaf_allocator_free(alloc: ddwaf_allocator, p: *mut ::std::os::raw::c_void, bytes: usize, alignment: usize) {}
     pub unsafe fn ddwaf_builder_add_or_update_config(builder: ddwaf_builder, path: *const std::os::raw::c_char, path_len: u32, config: *const ddwaf_object, diagnostics: *mut ddwaf_object) -> bool { false }
     pub unsafe fn ddwaf_builder_build_instance(builder: ddwaf_builder) -> ddwaf_handle { std::ptr::null_mut() }
     pub unsafe fn ddwaf_builder_destroy(builder: ddwaf_builder) {}
     pub unsafe fn ddwaf_builder_get_config_paths(builder: ddwaf_builder, paths: *mut ddwaf_object, filter: *const ::std::os::raw::c_char, filter_len: u32) -> u32 { 0 }
-    pub unsafe fn ddwaf_builder_init(config: *const ddwaf_config) -> ddwaf_builder { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_builder_init() -> ddwaf_builder { std::ptr::null_mut() }
     pub unsafe fn ddwaf_builder_remove_config(builder: ddwaf_builder, path: *const std::os::raw::c_char, path_len: u32) -> bool { false }
     pub unsafe fn ddwaf_context_destroy(context: ddwaf_context) {}
-    pub unsafe fn ddwaf_context_init(handle: ddwaf_handle) -> ddwaf_context { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_context_eval(context: ddwaf_context, data: *mut ddwaf_object, alloc: ddwaf_allocator, result: *mut ddwaf_object, timeout: u64) -> DDWAF_RET_CODE { DDWAF_ERR_INTERNAL }
+    pub unsafe fn ddwaf_context_init(handle: ddwaf_handle, output_alloc: ddwaf_allocator) -> ddwaf_context { std::ptr::null_mut() }
     pub unsafe fn ddwaf_destroy(handle: ddwaf_handle) {}
+    pub unsafe fn ddwaf_get_default_allocator() -> ddwaf_allocator { std::ptr::null_mut() }
     pub unsafe fn ddwaf_get_version() -> *const std::os::raw::c_char { std::ptr::null() }
+    pub unsafe fn ddwaf_init(ruleset: *const ddwaf_object, diagnostics: *mut ddwaf_object) -> ddwaf_handle { std::ptr::null_mut() }
     pub unsafe fn ddwaf_known_actions(handle: ddwaf_handle, size: *mut u32) -> *const *const ::std::os::raw::c_char { std::ptr::null() }
     pub unsafe fn ddwaf_known_addresses(handle: ddwaf_handle, size: *mut u32) -> *const *const ::std::os::raw::c_char { std::ptr::null() }
-    pub unsafe fn ddwaf_object_array(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_bool(object: *mut ddwaf_object, value: bool) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_float(object: *mut ddwaf_object, value: f64) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_free(object: *mut ddwaf_object) {}
-    pub unsafe fn ddwaf_object_from_json(output: *mut ddwaf_object, json_str: *const std::os::raw::c_char, length: u32) -> bool { false }
-    pub unsafe fn ddwaf_object_invalid(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_map(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_null(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_signed(object: *mut ddwaf_object, value: i64) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_stringl(object: *mut ddwaf_object, string: *const std::os::raw::c_char, length: usize) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_object_unsigned(object: *mut ddwaf_object, value: u64) -> *mut ddwaf_object { std::ptr::null_mut() }
-    pub unsafe fn ddwaf_run(context: ddwaf_context, persistent_data: *mut ddwaf_object, ephemeral_data: *mut ddwaf_object, result: *mut ddwaf_object, timeout: u64) -> DDWAF_RET_CODE { DDWAF_ERR_INTERNAL }
+    pub unsafe fn ddwaf_monotonic_allocator_init() -> ddwaf_allocator { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_at_key(object: *const ddwaf_object, index: usize) -> *const ddwaf_object { std::ptr::null() }
+    pub unsafe fn ddwaf_object_at_value(object: *const ddwaf_object, index: usize) -> *const ddwaf_object { std::ptr::null() }
+    pub unsafe fn ddwaf_object_clone(source: *const ddwaf_object, destination: *mut ddwaf_object, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_destroy(object: *mut ddwaf_object, alloc: ddwaf_allocator) {}
+    pub unsafe fn ddwaf_object_find(object: *const ddwaf_object, key: *const ::std::os::raw::c_char, length: usize) -> *const ddwaf_object { std::ptr::null() }
+    pub unsafe fn ddwaf_object_from_json(output: *mut ddwaf_object, json_str: *const std::os::raw::c_char, length: u32, alloc: ddwaf_allocator) -> bool { false }
+    pub unsafe fn ddwaf_object_get_bool(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_get_float(object: *const ddwaf_object) -> f64 { 0.0 }
+    pub unsafe fn ddwaf_object_get_length(object: *const ddwaf_object) -> usize { 0 }
+    pub unsafe fn ddwaf_object_get_signed(object: *const ddwaf_object) -> i64 { 0 }
+    pub unsafe fn ddwaf_object_get_size(object: *const ddwaf_object) -> usize { 0 }
+    pub unsafe fn ddwaf_object_get_string(object: *const ddwaf_object, length: *mut usize) -> *const ::std::os::raw::c_char { std::ptr::null() }
+    pub unsafe fn ddwaf_object_get_type(object: *const ddwaf_object) -> DDWAF_OBJ_TYPE { DDWAF_OBJ_INVALID }
+    pub unsafe fn ddwaf_object_get_unsigned(object: *const ddwaf_object) -> u64 { 0 }
+    pub unsafe fn ddwaf_object_insert(array: *mut ddwaf_object, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_insert_key(map: *mut ddwaf_object, key: *const ::std::os::raw::c_char, length: u32, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_insert_key_nocopy(map: *mut ddwaf_object, key: *const ::std::os::raw::c_char, length: u32, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_insert_literal_key(map: *mut ddwaf_object, key: *const ::std::os::raw::c_char, length: u32, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_is_array(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_bool(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_float(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_invalid(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_map(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_null(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_signed(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_string(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_is_unsigned(object: *const ddwaf_object) -> bool { false }
+    pub unsafe fn ddwaf_object_set_array(object: *mut ddwaf_object, capacity: u16, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_bool(object: *mut ddwaf_object, value: bool) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_float(object: *mut ddwaf_object, value: f64) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_invalid(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_map(object: *mut ddwaf_object, capacity: u16, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_null(object: *mut ddwaf_object) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_signed(object: *mut ddwaf_object, value: i64) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_string(object: *mut ddwaf_object, string: *const ::std::os::raw::c_char, length: u32, alloc: ddwaf_allocator) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_string_literal(object: *mut ddwaf_object, string: *const ::std::os::raw::c_char, length: u32) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_string_nocopy(object: *mut ddwaf_object, string: *const ::std::os::raw::c_char, length: u32) -> *mut ddwaf_object { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_object_set_unsigned(object: *mut ddwaf_object, value: u64) -> *mut ddwaf_object { std::ptr::null_mut() }
     pub unsafe fn ddwaf_set_log_cb(cb: ddwaf_log_cb, min_level: DDWAF_LOG_LEVEL) -> bool { false }
+    pub unsafe fn ddwaf_subcontext_destroy(subcontext: ddwaf_subcontext) {}
+    pub unsafe fn ddwaf_subcontext_eval(subcontext: ddwaf_subcontext, data: *mut ddwaf_object, alloc: ddwaf_allocator, result: *mut ddwaf_object, timeout: u64) -> DDWAF_RET_CODE { DDWAF_ERR_INTERNAL }
+    pub unsafe fn ddwaf_subcontext_init(context: ddwaf_context) -> ddwaf_subcontext { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_synchronized_pool_allocator_init() -> ddwaf_allocator { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_unsynchronized_pool_allocator_init() -> ddwaf_allocator { std::ptr::null_mut() }
+    pub unsafe fn ddwaf_user_allocator_init(alloc_fn: ddwaf_alloc_fn_type, free_fn: ddwaf_free_fn_type, udata: *mut ::std::os::raw::c_void, udata_free_fn: ddwaf_udata_free_fn_type) -> ddwaf_allocator { std::ptr::null_mut() }
 }

--- a/crates/libddwaf-sys/src/lib.rs
+++ b/crates/libddwaf-sys/src/lib.rs
@@ -24,27 +24,6 @@ unsafe impl Sync for ddwaf_object {}
 
 #[warn(clippy::pedantic)]
 impl ddwaf_object {
-    /// Drops the key associated with the receiving [`ddwaf_object`].
-    ///
-    /// # Safety
-    /// The key, if present, must be a raw-converted [`Box<[u8]>`]. After this method returns, the
-    /// values of [`ddwaf_object::parameterName`] and [`ddwaf_object::parameterNameLength`] must be
-    /// replaced as they will no longer be valid.
-    ///
-    /// # Panics
-    /// If the key is too large for this platform (can only happens on 32-bit platforms).
-    pub unsafe fn drop_key(&mut self) {
-        if self.parameterName.is_null() {
-            return;
-        }
-        let len =
-            usize::try_from(self.parameterNameLength).expect("key is too large for this platform");
-        let slice: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(self.parameterName.cast::<u8>().cast_mut(), len)
-        };
-        drop(unsafe { Box::from_raw(std::ptr::from_mut(slice)) });
-    }
-
     /// Drops the array data associated with the receiving [`ddwaf_object`].
     ///
     /// # Safety
@@ -52,23 +31,20 @@ impl ddwaf_object {
     /// - The array must be an [`std::alloc::alloc`]ated array of [`ddwaf_object`] of the proper size.
     /// - The individual elements of the array must be valid [`ddwaf_object`]s that can be dropped
     ///   with [`ddwaf_object::drop_object`].
-    ///
-    /// # Panics
-    /// If the array is too large for this platform (can only happens on 32-bit platforms).
+    #[allow(clippy::missing_panics_doc)]
     pub unsafe fn drop_array(&mut self) {
-        debug_assert_eq!(self.type_, DDWAF_OBJ_ARRAY);
-        if self.nbEntries == 0 {
+        debug_assert_eq!(self.obj_type(), DDWAF_OBJ_ARRAY);
+        let array = unsafe { self.via.array };
+        if array.capacity == 0 {
             return;
         }
-        let array = unsafe { self.__bindgen_anon_1.array };
-        let len = isize::try_from(self.nbEntries).expect("array is too large for this platform");
-        for i in 0..len {
-            let elem = unsafe { &mut *array.offset(i) };
+        for i in 0..array.size {
+            #[allow(clippy::cast_possible_wrap)]
+            let elem = unsafe { &mut *array.ptr.offset(i as isize) };
             unsafe { elem.drop_object() };
         }
-        #[allow(clippy::cast_possible_truncation)] // We could cast to isize, and usize is wider.
-        let layout = Layout::array::<ddwaf_object>(self.nbEntries as usize).unwrap();
-        unsafe { std::alloc::dealloc(array.cast(), layout) };
+        let layout = Layout::array::<ddwaf_object>(array.capacity as usize).unwrap();
+        unsafe { std::alloc::dealloc(array.ptr.cast(), layout) };
     }
 
     /// Drops the map data associated with the receiving [`ddwaf_object`].
@@ -78,24 +54,21 @@ impl ddwaf_object {
     /// - The map must be an [`std::alloc::alloc`]ated array of [`ddwaf_object`] of the proper size.
     /// - The individual elements of the map must be valid [`ddwaf_object`]s that can be dropped with
     ///   both [`ddwaf_object::drop_object`] and [`ddwaf_object::drop_key`].
-    ///
-    /// # Panics
-    /// If the map is too large for this platform (can only happens on 32-bit platforms).
+    #[allow(clippy::missing_panics_doc)]
     pub unsafe fn drop_map(&mut self) {
-        debug_assert_eq!(self.type_, DDWAF_OBJ_MAP);
-        if self.nbEntries == 0 {
+        debug_assert_eq!(self.obj_type(), DDWAF_OBJ_MAP);
+        let map = unsafe { self.via.map };
+        if map.capacity == 0 {
             return;
         }
-        let array = unsafe { self.__bindgen_anon_1.array };
-        let len = isize::try_from(self.nbEntries).expect("map is too large for this platform");
-        for i in 0..len {
-            let elem = unsafe { &mut *array.offset(i) };
-            unsafe { elem.drop_key() };
-            unsafe { elem.drop_object() };
+        for i in 0..map.size {
+            #[allow(clippy::cast_possible_wrap)]
+            let elem = unsafe { &mut *map.ptr.offset(i as isize) };
+            unsafe { elem.key.drop_object() };
+            unsafe { elem.val.drop_object() };
         }
-        #[allow(clippy::cast_possible_truncation)] // We could cast to isize, and usize is wider.
-        let layout = Layout::array::<ddwaf_object>(self.nbEntries as usize).unwrap();
-        unsafe { std::alloc::dealloc(array.cast(), layout) };
+        let layout = Layout::array::<_ddwaf_object_kv>(map.capacity as usize).unwrap();
+        unsafe { std::alloc::dealloc(map.ptr.cast(), layout) };
     }
 
     /// Drops the value associated with the receiving [`ddwaf_object`].
@@ -104,8 +77,9 @@ impl ddwaf_object {
     /// If the [`ddwaf_object`] is a string, array, or map, the respective requirements of the
     /// [`ddwaf_object::drop_string`], [`ddwaf_object::drop_array`], or [`ddwaf_object::drop_map`]
     /// methods apply.
+    /// The method can't be called more than once.
     pub unsafe fn drop_object(&mut self) {
-        match self.type_ {
+        match self.obj_type() {
             DDWAF_OBJ_STRING => unsafe { self.drop_string() },
             DDWAF_OBJ_ARRAY => unsafe { self.drop_array() },
             DDWAF_OBJ_MAP => unsafe { self.drop_map() },
@@ -113,102 +87,115 @@ impl ddwaf_object {
         }
     }
 
-    /// Drops the string associated with the receiving [`ddwaf_object`].
+    /// Drops the regular string associated with the receiving [`ddwaf_object`].
     ///
     /// # Safety
     /// - The [`ddwaf_object`] must be a valid representation of a string
-    /// - The [`ddwaf_object::__bindgen_anon_1`] field must have a
-    ///   [`_ddwaf_object__bindgen_ty_1::stringValue`] set from a raw-converted [`Box<[u8]>`]
-    ///
-    /// # Panics
-    /// If the string is too large for this platform (can only happens on 32-bit platforms).
+    /// - The [`_ddwaf_object__bindgen_ty_1::str_`] field must have a
+    ///   [`_ddwaf_object_string::ptr`] set from an allocation of `c_char` of the
+    ///   size indicated by the [`_ddwaf_object_string::size`] field done with [`std::alloc::alloc`].
+    #[allow(clippy::missing_panics_doc)]
     pub unsafe fn drop_string(&mut self) {
-        debug_assert_eq!(self.type_, DDWAF_OBJ_STRING);
-        let sval = unsafe { self.__bindgen_anon_1.stringValue };
+        debug_assert_eq!(self.obj_type(), DDWAF_OBJ_STRING);
+        let sval = unsafe { self.via.str_.ptr };
         if sval.is_null() {
             return;
         }
-        let len = usize::try_from(self.nbEntries).expect("string is too large for this platform");
-        let slice: &mut [u8] = unsafe { std::slice::from_raw_parts_mut(sval as *mut _, len) };
-        drop(unsafe { Box::from_raw(slice) });
+        unsafe {
+            std::alloc::dealloc(
+                sval.cast(),
+                Layout::array::<::std::os::raw::c_char>(self.via.str_.size as usize).unwrap(),
+            );
+        }
+    }
+
+    /// Returns the type of the [`ddwaf_object`]
+    #[must_use]
+    pub fn obj_type(&self) -> DDWAF_OBJ_TYPE {
+        DDWAF_OBJ_TYPE::from(unsafe { self.type_ })
+    }
+
+    /// Returns true if the [`ddwaf_object`] is a string.
+    #[must_use]
+    pub fn is_string(&self) -> bool {
+        (self.obj_type() & DDWAF_OBJ_STRING) != 0
+    }
+
+    /// Returns a slice of the bytes from the string associated with the receiving [`ddwaf_object`].
+    ///
+    /// # Safety
+    /// - The [`ddwaf_object`] must be a valid representation of a string.
+    unsafe fn string_vec(&self) -> &[u8] {
+        debug_assert!(self.is_string());
+
+        if self.obj_type() == DDWAF_OBJ_STRING || self.obj_type() == DDWAF_OBJ_LITERAL_STRING {
+            let str = unsafe { self.via.str_ };
+            if str.size == 0 {
+                return &[];
+            }
+            unsafe { slice::from_raw_parts(str.ptr.cast(), str.size as usize) }
+        } else {
+            let sstr = unsafe { &self.via.sstr };
+            let data = &sstr.data[..sstr.size as usize];
+            // reinterpret &[i8] as &[u8]
+            unsafe { std::slice::from_raw_parts(data.as_ptr().cast(), data.len()) }
+        }
     }
 }
+
 impl std::cmp::PartialEq<ddwaf_object> for ddwaf_object {
     fn eq(&self, other: &ddwaf_object) -> bool {
-        if self.type_ != other.type_ {
+        if self.is_string() && other.is_string() {
+            let left = unsafe { self.string_vec() };
+            let right = unsafe { other.string_vec() };
+            return left == right;
+        }
+
+        if unsafe { self.type_ != other.type_ } {
             return false;
         }
-        match self.type_ {
+        match self.obj_type() {
             DDWAF_OBJ_INVALID | DDWAF_OBJ_NULL => true,
-            DDWAF_OBJ_SIGNED => unsafe {
-                self.__bindgen_anon_1.intValue == other.__bindgen_anon_1.intValue
-            },
-            DDWAF_OBJ_UNSIGNED => unsafe {
-                self.__bindgen_anon_1.uintValue == other.__bindgen_anon_1.uintValue
-            },
-            DDWAF_OBJ_BOOL => unsafe {
-                self.__bindgen_anon_1.boolean == other.__bindgen_anon_1.boolean
-            },
-            DDWAF_OBJ_FLOAT => unsafe {
-                // We do an exact comparison here, which ought to be okay as we normally don't do math here...
-                self.__bindgen_anon_1.f64_ == other.__bindgen_anon_1.f64_
-            },
-
-            // Strings are a pointer, we need to compare the data they point to...
-            DDWAF_OBJ_STRING => unsafe {
-                if self.nbEntries != other.nbEntries {
+            DDWAF_OBJ_SIGNED => unsafe { self.via.i64_.val == other.via.i64_.val },
+            DDWAF_OBJ_UNSIGNED => unsafe { self.via.u64_.val == other.via.u64_.val },
+            DDWAF_OBJ_BOOL => unsafe { self.via.b8.val == other.via.b8.val },
+            DDWAF_OBJ_FLOAT => unsafe { self.via.f64_.val == other.via.f64_.val },
+            DDWAF_OBJ_ARRAY => {
+                let left = unsafe { self.via.array };
+                let right = unsafe { other.via.array };
+                if left.size != right.size {
                     return false;
                 }
-                if self.nbEntries == 0 {
+                if left.size == 0 {
                     return true;
                 }
-                let len =
-                    usize::try_from(self.nbEntries).expect("string is too large for this platform");
-                let left = slice::from_raw_parts(self.__bindgen_anon_1.stringValue, len);
-                let right = slice::from_raw_parts(other.__bindgen_anon_1.stringValue, len);
-                left == right
-            },
-
-            // Arrays and maps are pointers to collections, we need to compare the data they point to...
-            DDWAF_OBJ_ARRAY | DDWAF_OBJ_MAP => unsafe {
-                if self.nbEntries != other.nbEntries {
-                    return false;
-                }
-                if self.nbEntries == 0 {
-                    return true;
-                }
-
-                let left = slice::from_raw_parts(
-                    self.__bindgen_anon_1.array,
-                    usize::try_from(self.nbEntries)
-                        .expect("array/map is too large for this platform"),
-                );
-                let right = slice::from_raw_parts(
-                    other.__bindgen_anon_1.array,
-                    usize::try_from(other.nbEntries)
-                        .expect("array/map is too large for this platform"),
-                );
-                for (left, right) in left.iter().zip(right.iter()) {
-                    if self.type_ == DDWAF_OBJ_MAP {
-                        if left.parameterNameLength != right.parameterNameLength {
-                            return false;
-                        }
-                        let len = usize::try_from(left.parameterNameLength)
-                            .expect("key is too large for this platform");
-                        if len > 0 {
-                            let left_key = slice::from_raw_parts(left.parameterName, len);
-                            let right_key = slice::from_raw_parts(right.parameterName, len);
-                            if left_key != right_key {
-                                return false;
-                            }
-                        }
-                    }
+                for i in 0..left.size {
+                    let left = unsafe { &*left.ptr.offset(i as isize) };
+                    let right = unsafe { &*right.ptr.offset(i as isize) };
                     if left != right {
                         return false;
                     }
                 }
                 true
-            },
+            }
+            DDWAF_OBJ_MAP => {
+                let left = unsafe { self.via.map };
+                let right = unsafe { other.via.map };
+                if left.size != right.size {
+                    return false;
+                }
+                if left.size == 0 {
+                    return true;
+                }
+                for i in 0..left.size {
+                    let left = unsafe { &*left.ptr.offset(i as isize) };
+                    let right = unsafe { &*right.ptr.offset(i as isize) };
+                    if left.key != right.key || left.val != right.val {
+                        return false;
+                    }
+                }
+                true
+            }
 
             _ => false,
         }
@@ -217,62 +204,51 @@ impl std::cmp::PartialEq<ddwaf_object> for ddwaf_object {
 impl std::fmt::Debug for ddwaf_object {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("ddwaf_object");
-        let dbg = match usize::try_from(self.parameterNameLength) {
-            Ok(0) => &mut dbg,
-            Ok(len) => {
-                let key = unsafe { slice::from_raw_parts(self.parameterName.cast(), len) };
-                let key = String::from_utf8_lossy(key);
-                dbg.field("parameterName", &key)
-            }
-            Err(_) => {
-                let key = unsafe { slice::from_raw_parts(self.parameterName.cast(), usize::MAX) };
-                let key = String::from_utf8_lossy(key);
-                dbg.field("parameterName(trunc)", &key)
-            }
-        };
-        let dbg = match self.type_ {
+        match self.obj_type() {
             DDWAF_OBJ_BOOL => dbg
                 .field("type", &stringify!(DDWAF_OBJ_BOOL))
-                .field("boolean", unsafe { &self.__bindgen_anon_1.boolean }),
+                .field("boolean", unsafe { &self.via.b8.val }),
             DDWAF_OBJ_FLOAT => dbg
                 .field("type", &stringify!(DDWAF_OBJ_FLOAT))
-                .field("f64", unsafe { &self.__bindgen_anon_1.f64_ }),
+                .field("f64", unsafe { &self.via.f64_.val }),
             DDWAF_OBJ_SIGNED => dbg
                 .field("type", &stringify!(DDWAF_OBJ_SIGNED))
-                .field("int", unsafe { &self.__bindgen_anon_1.intValue }),
+                .field("int", unsafe { &self.via.i64_.val }),
             DDWAF_OBJ_UNSIGNED => dbg
                 .field("type", &stringify!(DDWAF_OBJ_UNSIGNED))
-                .field("uint", unsafe { &self.__bindgen_anon_1.uintValue }),
-            DDWAF_OBJ_STRING => {
-                let (field, len) = match usize::try_from(self.nbEntries) {
-                    Ok(len) => ("string", len),
-                    Err(_) => ("string(trunc)", usize::MAX),
-                };
-                let sval =
-                    unsafe { slice::from_raw_parts(self.__bindgen_anon_1.stringValue.cast(), len) };
+                .field("uint", unsafe { &self.via.u64_.val }),
+            DDWAF_OBJ_STRING | DDWAF_OBJ_LITERAL_STRING => {
+                let sval = unsafe { self.string_vec() };
                 let sval = String::from_utf8_lossy(sval);
-                dbg.field("type", &stringify!(DDWAF_OBJ_STRING))
-                    .field(field, &sval)
+                dbg.field(
+                    "type",
+                    if self.obj_type() == DDWAF_OBJ_STRING {
+                        &stringify!(DDWAF_OBJ_STRING)
+                    } else {
+                        &stringify!(DDWAF_OBJ_LITERAL_STRING)
+                    },
+                )
+                .field("string", &sval)
+            }
+            DDWAF_OBJ_SMALL_STRING => {
+                let sval = unsafe { self.string_vec() };
+                let sval = String::from_utf8_lossy(sval);
+                dbg.field("type", &stringify!(DDWAF_OBJ_SMALL_STRING))
+                    .field("string", &sval)
             }
             DDWAF_OBJ_ARRAY => {
-                let (field, len) = match usize::try_from(self.nbEntries) {
-                    Ok(len) => ("array", len),
-                    Err(_) => ("array(trunc)", usize::MAX),
-                };
+                let array = unsafe { self.via.array };
                 let array: &[ddwaf_object] =
-                    unsafe { slice::from_raw_parts(self.__bindgen_anon_1.array.cast(), len) };
+                    unsafe { slice::from_raw_parts(array.ptr.cast(), array.size as usize) };
                 dbg.field("type", &stringify!(DDWAF_OBJ_ARRAY))
-                    .field(field, &array)
+                    .field("array", &array)
             }
             DDWAF_OBJ_MAP => {
-                let (field, len) = match usize::try_from(self.nbEntries) {
-                    Ok(len) => ("map", len),
-                    Err(_) => ("map(trunc)", usize::MAX),
-                };
-                let array: &[ddwaf_object] =
-                    unsafe { slice::from_raw_parts(self.__bindgen_anon_1.array.cast(), len) };
+                let map = unsafe { self.via.map };
+                let map: &[_ddwaf_object_kv] =
+                    unsafe { slice::from_raw_parts(map.ptr.cast(), map.size as usize) };
                 dbg.field("type", &stringify!(DDWAF_OBJ_MAP))
-                    .field(field, &array)
+                    .field("map", &map)
             }
             DDWAF_OBJ_NULL => dbg.field("type", &stringify!(DDWAF_OBJ_NULL)),
             DDWAF_OBJ_INVALID => dbg.field("type", &stringify!(DDWAF_OBJ_INVALID)),
@@ -280,5 +256,14 @@ impl std::fmt::Debug for ddwaf_object {
         };
 
         dbg.finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for _ddwaf_object_kv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("ddwaf_object_kv");
+        dbg.field("key", &self.key)
+            .field("val", &self.val)
+            .finish_non_exhaustive()
     }
 }

--- a/crates/libddwaf-sys/src/lib.rs
+++ b/crates/libddwaf-sys/src/lib.rs
@@ -39,10 +39,13 @@ impl ddwaf_object {
             return;
         }
         for i in 0..array.size {
+            // We don't support 16-bit isize, so the unsigned -> signed cast is safe.
             #[allow(clippy::cast_possible_wrap)]
             let elem = unsafe { &mut *array.ptr.offset(i as isize) };
             unsafe { elem.drop_object() };
         }
+        // Could only panic if sizeof(ddwaf_object) * capacity > isize::MAX, which can't happen
+        // given that capacity is limited to u16::MAX.
         let layout = Layout::array::<ddwaf_object>(array.capacity as usize).unwrap();
         unsafe { std::alloc::dealloc(array.ptr.cast(), layout) };
     }

--- a/crates/libddwaf-sys/tests/tests.rs
+++ b/crates/libddwaf-sys/tests/tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::ffi::{CStr, CString};
 
 use libddwaf_sys::*;

--- a/crates/libddwaf-sys/tests/tests.rs
+++ b/crates/libddwaf-sys/tests/tests.rs
@@ -379,7 +379,8 @@ fn test_eq_array_and_map() {
     let mut items2 = [_ddwaf_object_kv::default()];
     unsafe {
         ddwaf_object_set_unsigned(&mut items2[0].val, 42);
-        ddwaf_object_set_string_literal(&mut items2[0].key, b"yek".as_ptr().cast(), 3); // Different key
+        ddwaf_object_set_string_literal(&mut items2[0].key, b"yek".as_ptr().cast(), 3);
+        // Different key
     };
 
     let mut wrong = ddwaf_object::default();

--- a/crates/libddwaf-sys/tests/tests.rs
+++ b/crates/libddwaf-sys/tests/tests.rs
@@ -4,6 +4,12 @@ use libddwaf_sys::*;
 
 #[test]
 fn test_version() {
+    // Skip this test if LIBDDWAF_PREFIX is set, as it will use a different version
+    if std::env::var("LIBDDWAF_PREFIX").is_ok() {
+        eprintln!("Skipping test_version: LIBDDWAF_PREFIX is set");
+        return;
+    }
+
     let version = unsafe { ddwaf_get_version() };
     assert!(!version.is_null());
     assert_eq!(
@@ -24,12 +30,11 @@ fn test_eq_invalid() {
 #[test]
 fn test_eq_null() {
     let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_null(&mut left) };
+    unsafe { ddwaf_object_set_null(&mut left) };
 
-    let right = ddwaf_object {
-        type_: DDWAF_OBJ_NULL,
-        ..ddwaf_object::default()
-    };
+    let mut right = ddwaf_object::default();
+    right.type_ = DDWAF_OBJ_NULL as u8;
+
     assert_eq!(left, right);
     assert_ne!(left, ddwaf_object::default());
 }
@@ -37,229 +42,377 @@ fn test_eq_null() {
 #[test]
 fn test_eq_signed() {
     let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_signed(&mut left, -42) };
-    assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_SIGNED,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { intValue: -42 },
-            ..ddwaf_object::default()
-        }
-    );
+    unsafe { ddwaf_object_set_signed(&mut left, -42) };
 
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_SIGNED,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { intValue: 42 }, // Sign mismatch
-            ..ddwaf_object::default()
-        }
-    );
+    let mut right = ddwaf_object::default();
+    right.via.i64_ = _ddwaf_object_signed {
+        type_: DDWAF_OBJ_SIGNED as u8,
+        val: -42,
+    };
+    assert_eq!(left, right);
+
+    let mut wrong = ddwaf_object::default();
+    wrong.via.i64_ = _ddwaf_object_signed {
+        type_: DDWAF_OBJ_SIGNED as u8,
+        val: 42,
+    };
+    assert_ne!(left, wrong);
     assert_ne!(left, ddwaf_object::default());
 }
 
 #[test]
 fn test_eq_unsigned() {
     let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_unsigned(&mut left, 1337) };
+    unsafe { ddwaf_object_set_unsigned(&mut left, 1337) };
 
-    assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_UNSIGNED,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { uintValue: 1337 },
-            ..ddwaf_object::default()
-        }
-    );
+    let mut right = ddwaf_object::default();
+    right.via.u64_ = _ddwaf_object_unsigned {
+        type_: DDWAF_OBJ_UNSIGNED as u8,
+        val: 1337,
+    };
+    assert_eq!(left, right);
 
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_UNSIGNED,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { uintValue: 42 }, // Value mismatch
-            ..ddwaf_object::default()
-        }
-    );
+    let mut wrong = ddwaf_object::default();
+    wrong.via.u64_ = _ddwaf_object_unsigned {
+        type_: DDWAF_OBJ_UNSIGNED as u8,
+        val: 42,
+    };
+    assert_ne!(left, wrong);
     assert_ne!(left, ddwaf_object::default());
 }
 
 #[test]
 fn test_eq_bool() {
     let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_bool(&mut left, true) };
+    unsafe { ddwaf_object_set_bool(&mut left, true) };
 
-    assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_BOOL,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { boolean: true },
-            ..ddwaf_object::default()
-        }
-    );
+    let mut right = ddwaf_object::default();
+    right.via.b8 = _ddwaf_object_bool {
+        type_: DDWAF_OBJ_BOOL as u8,
+        val: true,
+    };
+    assert_eq!(left, right);
 
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_BOOL,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { boolean: false }, // Value mismatch
-            ..ddwaf_object::default()
-        }
-    );
+    let mut wrong = ddwaf_object::default();
+    wrong.via.b8 = _ddwaf_object_bool {
+        type_: DDWAF_OBJ_BOOL as u8,
+        val: false,
+    };
+    assert_ne!(left, wrong);
     assert_ne!(left, ddwaf_object::default());
 }
 
 #[test]
 fn test_eq_float() {
     let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_float(&mut left, 1337.42) };
+    unsafe { ddwaf_object_set_float(&mut left, 1337.42) };
 
-    assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_FLOAT,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { f64_: 1337.42 },
-            ..ddwaf_object::default()
-        }
-    );
+    let mut right = ddwaf_object::default();
+    right.via.f64_ = _ddwaf_object_float {
+        type_: DDWAF_OBJ_FLOAT as u8,
+        val: 1337.42,
+    };
+    assert_eq!(left, right);
 
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_FLOAT,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 { f64_: 1337.0 }, // Value mismatch
-            ..ddwaf_object::default()
-        }
-    );
+    let mut wrong = ddwaf_object::default();
+    wrong.via.f64_ = _ddwaf_object_float {
+        type_: DDWAF_OBJ_FLOAT as u8,
+        val: 1337.0,
+    };
+    assert_ne!(left, wrong);
     assert_ne!(left, ddwaf_object::default());
 }
 
 #[test]
 fn test_eq_string() {
-    let mut left = ddwaf_object::default();
-    let blank = CString::new("").expect("Failed to create blank CString");
-    unsafe { ddwaf_object_stringl(&mut left, blank.as_ref().as_ptr().cast(), 0) };
+    // Test empty literal string
+    let mut empty_literal = ddwaf_object::default();
+    let blank = b"";
+    unsafe { ddwaf_object_set_string_literal(&mut empty_literal, blank.as_ptr().cast(), 0) };
+
+    let mut empty_expected = ddwaf_object::default();
+    empty_expected.via.str_ = _ddwaf_object_string {
+        type_: DDWAF_OBJ_LITERAL_STRING as u8,
+        size: 0,
+        ptr: std::ptr::null_mut(),
+    };
+    assert_eq!(empty_literal, empty_expected);
+
+    // Test literal string
+    let test_str = b"Hello, world!";
+    let mut literal = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut literal,
+            test_str.as_ptr().cast(),
+            test_str.len() as u32,
+        )
+    };
+
+    let mut literal_expected = ddwaf_object::default();
+    literal_expected.via.str_ = _ddwaf_object_string {
+        type_: DDWAF_OBJ_LITERAL_STRING as u8,
+        size: 13,
+        ptr: test_str.as_ptr() as *mut _,
+    };
+    assert_eq!(literal, literal_expected);
+
+    // Test regular (allocated) string with same content
+    // Note: We use ddwaf_object_set_string_literal for testing equality semantics
+    // without needing to manage allocations in the test
+    let mut regular_as_literal = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut regular_as_literal,
+            test_str.as_ptr().cast(),
+            test_str.len() as u32,
+        )
+    };
+
+    // Different string type objects with same content should be equal (cross-type comparison)
     assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_STRING,
-            ..ddwaf_object::default()
-        }
+        regular_as_literal, literal,
+        "Strings with same content should be equal regardless of type"
     );
 
-    let mut left = ddwaf_object::default();
-    unsafe { ddwaf_object_stringl(&mut left, b"Hello, world!".as_ptr().cast(), 13) };
+    // Test small string (short strings are stored inline)
+    let small_str = b"Hi";
+    let mut small_literal = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut small_literal,
+            small_str.as_ptr().cast(),
+            small_str.len() as u32,
+        )
+    };
 
-    let str = String::from("Hello, world!");
+    let mut small_literal2 = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut small_literal2,
+            small_str.as_ptr().cast(),
+            small_str.len() as u32,
+        )
+    };
+
+    // Small strings should compare equal
     assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_STRING,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                stringValue: str.as_bytes().as_ptr().cast(),
-            },
-            nbEntries: str.len() as _,
-            ..ddwaf_object::default()
-        }
+        small_literal, small_literal2,
+        "Small strings with same content should be equal"
     );
 
-    let str = String::from("Hello, world");
+    // Test that small and regular strings with same content are equal
+    let same_content = b"Hi";
+    let mut another_small = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut another_small,
+            same_content.as_ptr().cast(),
+            same_content.len() as u32,
+        )
+    };
+    assert_eq!(
+        small_literal, another_small,
+        "Strings with same content should be equal"
+    );
+
+    // Test length mismatch
+    let mut wrong = ddwaf_object::default();
+    wrong.via.str_ = _ddwaf_object_string {
+        type_: DDWAF_OBJ_LITERAL_STRING as u8,
+        size: 12, // Length mismatch
+        ptr: test_str.as_ptr() as *mut _,
+    };
+    assert_ne!(literal, wrong);
+
+    // Test content mismatch
+    let other_str = b"Different!!!";
+    let mut different = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut different,
+            other_str.as_ptr().cast(),
+            other_str.len() as u32,
+        )
+    };
     assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_STRING,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                stringValue: str.as_bytes().as_ptr().cast(),
-            },
-            nbEntries: str.len() as _, // Length mismatch
-            ..ddwaf_object::default()
-        }
+        literal, different,
+        "Strings with different content should not be equal"
     );
-    assert_ne!(left, ddwaf_object::default());
+
+    assert_ne!(literal, ddwaf_object::default());
+}
+
+#[test]
+fn test_eq_string_types_with_allocator() {
+    let alloc = unsafe { ddwaf_get_default_allocator() };
+
+    // Use a longer string to ensure it's stored as DDWAF_OBJ_STRING, not DDWAF_OBJ_SMALL_STRING
+    let test_str: [u8; 53] = *b"This is a longer test string that should not be small";
+
+    let mut regular_string = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_nocopy(
+            &mut regular_string,
+            test_str.as_ptr().cast(),
+            test_str.len() as u32,
+        );
+    }
+
+    let regular_type = unsafe { ddwaf_object_get_type(&regular_string) };
+    assert_eq!(
+        regular_type, DDWAF_OBJ_STRING,
+        "Long allocated string should be DDWAF_OBJ_STRING"
+    );
+
+    // Create a literal string with same content
+    let mut literal_string = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut literal_string,
+            test_str.as_ptr().cast(),
+            test_str.len() as u32,
+        );
+    }
+
+    let literal_type = unsafe { ddwaf_object_get_type(&literal_string) };
+    assert_eq!(
+        literal_type, DDWAF_OBJ_LITERAL_STRING,
+        "Literal string should be DDWAF_OBJ_LITERAL_STRING"
+    );
+
+    // Regular and literal strings with same content should be equal (cross-type comparison)
+    assert_eq!(
+        regular_string, literal_string,
+        "Regular and literal strings with same content should be equal"
+    );
+
+    // Test with very small strings that will use small string optimization
+    let small_str = b"hi";
+
+    let mut small_allocated = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string(
+            &mut small_allocated,
+            small_str.as_ptr().cast(),
+            small_str.len() as u32,
+            alloc,
+        );
+    }
+
+    let small_type = unsafe { ddwaf_object_get_type(&small_allocated) };
+    assert_eq!(
+        small_type, DDWAF_OBJ_SMALL_STRING,
+        "Short allocated string should be DDWAF_OBJ_SMALL_STRING"
+    );
+
+    let mut small_literal = ddwaf_object::default();
+    unsafe {
+        ddwaf_object_set_string_literal(
+            &mut small_literal,
+            small_str.as_ptr().cast(),
+            small_str.len() as u32,
+        );
+    }
+
+    let small_lit_type = unsafe { ddwaf_object_get_type(&small_literal) };
+    assert_eq!(
+        small_lit_type, DDWAF_OBJ_LITERAL_STRING,
+        "Short literal string should be DDWAF_OBJ_LITERAL_STRING"
+    );
+
+    // Small strings should also compare equal across types
+    assert_eq!(
+        small_allocated, small_literal,
+        "Small strings should be equal regardless of how they were created"
+    );
 }
 
 #[test]
 fn test_eq_array_and_map() {
-    // NB -- Map is a superset of array, so we don't test arrays separately.
-
-    assert_eq!(
-        ddwaf_object {
-            type_: DDWAF_OBJ_ARRAY,
-            ..ddwaf_object::default()
-        },
-        ddwaf_object {
-            type_: DDWAF_OBJ_ARRAY,
-            ..ddwaf_object::default()
-        }
-    );
-
-    let mut items = [ddwaf_object::default()];
-    unsafe { ddwaf_object_unsigned(&mut items[0], 42) };
-    items[0].parameterName = b"key".as_ptr().cast();
-    items[0].parameterNameLength = 3;
-
-    let left = ddwaf_object {
-        type_: DDWAF_OBJ_MAP,
-        nbEntries: 1,
-        __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-            array: items.as_mut_ptr().cast(),
-        },
-        ..ddwaf_object::default()
+    // Test empty arrays
+    let mut arr_left = ddwaf_object::default();
+    arr_left.via.array = _ddwaf_object_array {
+        type_: DDWAF_OBJ_ARRAY as u8,
+        size: 0,
+        capacity: 0,
+        ptr: std::ptr::null_mut(),
     };
 
-    assert_eq!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_MAP,
-            nbEntries: 1,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                array: items.as_mut_ptr().cast(),
-            },
-            ..ddwaf_object::default()
-        }
-    );
+    let mut arr_right = ddwaf_object::default();
+    arr_right.via.array = _ddwaf_object_array {
+        type_: DDWAF_OBJ_ARRAY as u8,
+        size: 0,
+        capacity: 0,
+        ptr: std::ptr::null_mut(),
+    };
 
-    let mut items = [ddwaf_object::default()];
-    unsafe { ddwaf_object_unsigned(&mut items[0], 42) };
-    items[0].parameterName = b"yek".as_ptr().cast();
-    items[0].parameterNameLength = 3;
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_MAP,
-            nbEntries: 1,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                array: items.as_mut_ptr().cast(), // Key mismatch
-            },
-            ..ddwaf_object::default()
-        }
-    );
+    assert_eq!(arr_left, arr_right);
 
-    let mut items = [ddwaf_object::default()];
-    unsafe { ddwaf_object_signed(&mut items[0], -1337) };
-    items[0].parameterName = b"key".as_ptr().cast();
-    items[0].parameterNameLength = 3;
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_MAP,
-            nbEntries: 1,
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                array: items.as_mut_ptr().cast(), // Value mismatch
-            },
-            ..ddwaf_object::default()
-        }
-    );
+    // Test map with one entry
+    let mut items = [_ddwaf_object_kv::default()];
+    unsafe {
+        ddwaf_object_set_unsigned(&mut items[0].val, 42);
+        ddwaf_object_set_string_literal(&mut items[0].key, b"key".as_ptr().cast(), 3);
+    };
 
-    assert_ne!(
-        left,
-        ddwaf_object {
-            type_: DDWAF_OBJ_MAP,
-            nbEntries: 0, // Length mismatch
-            __bindgen_anon_1: _ddwaf_object__bindgen_ty_1 {
-                array: items.as_mut_ptr().cast()
-            },
-            ..ddwaf_object::default()
-        }
-    );
+    let mut left = ddwaf_object::default();
+    left.via.map = _ddwaf_object_map {
+        type_: DDWAF_OBJ_MAP as u8,
+        size: 1,
+        capacity: 1,
+        ptr: items.as_mut_ptr(),
+    };
+
+    let mut right = ddwaf_object::default();
+    right.via.map = _ddwaf_object_map {
+        type_: DDWAF_OBJ_MAP as u8,
+        size: 1,
+        capacity: 1,
+        ptr: items.as_mut_ptr(),
+    };
+    assert_eq!(left, right);
+
+    // Test key mismatch
+    let mut items2 = [_ddwaf_object_kv::default()];
+    unsafe {
+        ddwaf_object_set_unsigned(&mut items2[0].val, 42);
+        ddwaf_object_set_string_literal(&mut items2[0].key, b"yek".as_ptr().cast(), 3); // Different key
+    };
+
+    let mut wrong = ddwaf_object::default();
+    wrong.via.map = _ddwaf_object_map {
+        type_: DDWAF_OBJ_MAP as u8,
+        size: 1,
+        capacity: 1,
+        ptr: items2.as_mut_ptr(),
+    };
+    assert_ne!(left, wrong);
+
+    // Test value mismatch
+    let mut items3 = [_ddwaf_object_kv::default()];
+    unsafe {
+        ddwaf_object_set_signed(&mut items3[0].val, -1337); // Different value type
+        ddwaf_object_set_string_literal(&mut items3[0].key, b"key".as_ptr().cast(), 3);
+    };
+
+    let mut wrong2 = ddwaf_object::default();
+    wrong2.via.map = _ddwaf_object_map {
+        type_: DDWAF_OBJ_MAP as u8,
+        size: 1,
+        capacity: 1,
+        ptr: items3.as_mut_ptr(),
+    };
+    assert_ne!(left, wrong2);
+
+    // Test size mismatch
+    let mut wrong3 = ddwaf_object::default();
+    wrong3.via.map = _ddwaf_object_map {
+        type_: DDWAF_OBJ_MAP as u8,
+        size: 0, // Size mismatch
+        capacity: 1,
+        ptr: items.as_mut_ptr(),
+    };
+    assert_ne!(left, wrong3);
     assert_ne!(left, ddwaf_object::default());
 }

--- a/crates/libddwaf/Cargo.toml
+++ b/crates/libddwaf/Cargo.toml
@@ -20,7 +20,10 @@ serde_json = "1.0"
 default = ["serde"]
 fips = ["libddwaf-sys/fips"]
 serde = ["dep:serde"]
+# Embeds libddwaf and loads it with dlopen at runtime (no external library needed)
 dynamic = ["libddwaf-sys/dynamic"]
+# Links to libddwaf dynamically via system linker (requires libddwaf.so at runtime)
+dynamic-link = ["libddwaf-sys/dynamic-link"]
 
 [lints]
 workspace = true

--- a/crates/libddwaf/Cargo.toml
+++ b/crates/libddwaf/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false }
+libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false, features = ["link-stdcxx"] }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/crates/libddwaf/Cargo.toml
+++ b/crates/libddwaf/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false }
+libddwaf-sys = { version = "2.0.0-alpha0", path = "../libddwaf-sys", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/crates/libddwaf/Cargo.toml
+++ b/crates/libddwaf/Cargo.toml
@@ -10,7 +10,7 @@ categories.workspace = true
 keywords.workspace = true
 
 [dependencies]
-libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false, features = ["link-stdcxx"] }
+libddwaf-sys = { version = "1.26.0", path = "../libddwaf-sys", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -24,6 +24,8 @@ serde = ["dep:serde"]
 dynamic = ["libddwaf-sys/dynamic"]
 # Links to libddwaf dynamically via system linker (requires libddwaf.so at runtime)
 dynamic-link = ["libddwaf-sys/dynamic-link"]
+# Link against libstdc++
+link-stdcxx = ["libddwaf-sys/link-stdcxx"]
 
 [lints]
 workspace = true

--- a/crates/libddwaf/src/builder.rs
+++ b/crates/libddwaf/src/builder.rs
@@ -13,16 +13,28 @@ pub struct Builder {
     raw: libddwaf_sys::ddwaf_builder,
 }
 impl Builder {
+    const OBFUSCATOR_KEY: &str = "datadog/0/ASM_DD/0/config";
+
     /// Creates a new [`Builder`] instance using the provided [`Config`]. Returns [`None`] if the
     /// builder's initialization fails.
     #[must_use]
-    pub fn new(config: &Config) -> Option<Self> {
-        let builder = Builder {
-            raw: unsafe { libddwaf_sys::ddwaf_builder_init(&raw const config.raw) },
+    pub fn new(config: Option<&Config>) -> Option<Self> {
+        let mut builder = Builder {
+            raw: unsafe { libddwaf_sys::ddwaf_builder_init() },
         };
         if builder.raw.is_null() {
             return None;
         }
+
+        if let Some(config) = config {
+            let config_obj = config.as_waf_object();
+            let res = builder.add_or_update_config(Self::OBFUSCATOR_KEY, &config_obj, None);
+            if !res {
+                debug_assert!(false, "Failed to add or update obfuscator config");
+                return None;
+            }
+        }
+
         Some(builder)
     }
 

--- a/crates/libddwaf/src/builder.rs
+++ b/crates/libddwaf/src/builder.rs
@@ -1,6 +1,6 @@
 use std::ptr::null_mut;
 
-use crate::object::{AsRawMutObject, WafArray, WafMap, WafOwned};
+use crate::object::{AsRawMutObject, WafArray, WafMap, WafOwnedDefaultAllocator};
 use crate::{Config, Handle};
 
 /// A builder for [`Handle`]s.
@@ -50,7 +50,7 @@ impl Builder {
         &mut self,
         path: &str,
         ruleset: &impl AsRef<libddwaf_sys::ddwaf_object>,
-        diagnostics: Option<&mut WafOwned<WafMap>>,
+        diagnostics: Option<&mut WafOwnedDefaultAllocator<WafMap>>,
     ) -> bool {
         debug_assert!(
             !path.is_empty(),
@@ -110,8 +110,9 @@ impl Builder {
     /// # Panics
     /// Panics if the provided `filter` regular expression is longer than [`u32::MAX`] bytes.
     #[must_use]
-    pub fn config_paths(&mut self, filter: Option<&'_ str>) -> WafOwned<WafArray> {
-        let mut res = WafOwned::<WafArray>::default();
+    pub fn config_paths(&mut self, filter: Option<&'_ str>) -> WafOwnedDefaultAllocator<WafArray> {
+        // SAFETY: ddwaf_builder_get_config_paths uses the default allocator
+        let mut res = WafOwnedDefaultAllocator::<WafArray>::default();
         let filter = filter.unwrap_or("");
         let filter_len = u32::try_from(filter.len()).expect("filter is too long");
         let _ = unsafe {

--- a/crates/libddwaf/src/builder.rs
+++ b/crates/libddwaf/src/builder.rs
@@ -50,7 +50,7 @@ impl Builder {
         &mut self,
         path: &str,
         ruleset: &impl AsRef<libddwaf_sys::ddwaf_object>,
-        diagnostics: Option<&mut WafOwnedDefaultAllocator<WafMap>>,
+        mut diagnostics: Option<&mut WafOwnedDefaultAllocator<WafMap>>,
     ) -> bool {
         debug_assert!(
             !path.is_empty(),
@@ -61,6 +61,10 @@ impl Builder {
             )
         );
         let path_len = u32::try_from(path.len()).expect("path is too long");
+        if let Some(ref mut diagnostics) = diagnostics {
+            // drop the old diagnostics if we're reusing it
+            let _ = std::mem::take(*diagnostics);
+        }
         unsafe {
             libddwaf_sys::ddwaf_builder_add_or_update_config(
                 self.raw,

--- a/crates/libddwaf/src/config.rs
+++ b/crates/libddwaf/src/config.rs
@@ -74,15 +74,9 @@ impl Obfuscator {
     }
 }
 
-/// The regular expression used by [`Obfuscator::default`] to determine which key data to obfuscate.
-pub const OBFUSCATOR_DEFAULT_KEY_REGEX: &str = r"(?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt";
-/// The regular expression used by [`Obfuscator::default`] to determine which value data to obfuscate.
-pub const OBFUSCATOR_DEFAULT_VAL_REGEX: &str = r#"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:[_-]?phrase)?|secret(?:[_-]?key)?|(?:(?:api|private|public|access)[_-]?)key(?:[_-]?id)?|(?:(?:auth|access|id|refresh)[_-]?)?token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?|jsessionid|phpsessid|asp\.net(?:[_-]|-)sessionid|sid|jwt)(?:\s*=([^;&]+)|"\s*:\s*("[^"]+"|\d+))|bearer\s+([a-z0-9\._\-]+)|token\s*:\s*([a-z0-9]{13})|gh[opsu]_([0-9a-zA-Z]{36})|ey[I-L][\w=-]+\.(ey[I-L][\w=-]+(?:\.[\w.+\/=-]+)?)|[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}([^\-]+)[\-]{5}END[a-z\s]+PRIVATE\sKEY|ssh-rsa\s*([a-z0-9\/\.+]{100,})"#;
 impl Default for Obfuscator {
     fn default() -> Self {
-        Obfuscator::new(
-            Some(OBFUSCATOR_DEFAULT_KEY_REGEX),
-            Some(OBFUSCATOR_DEFAULT_VAL_REGEX),
-        )
+        // This actually uses the default regexes from libddwaf
+        Obfuscator::new(None::<&str>, None::<&str>)
     }
 }

--- a/crates/libddwaf/src/config.rs
+++ b/crates/libddwaf/src/config.rs
@@ -60,22 +60,15 @@ impl Obfuscator {
     /// Returns the regular expression used to determine key data to be obfuscated, if one has been
     /// set.
     #[must_use]
-    pub const fn key_regex(&self) -> Option<&[u8]> {
-        // as_deref() is not const
-        match self.key_regex.as_ref() {
-            Some(v) => Some(v.as_slice()),
-            None => None,
-        }
+    pub fn key_regex(&self) -> Option<&[u8]> {
+        self.key_regex.as_deref()
     }
 
     /// Returns the regular expression used to determine value data to be obfuscated, if one has
     /// been set.
     #[must_use]
-    pub const fn value_regex(&self) -> Option<&[u8]> {
-        match self.value_regex.as_ref() {
-            Some(v) => Some(v.as_slice()),
-            None => None,
-        }
+    pub fn value_regex(&self) -> Option<&[u8]> {
+        self.value_regex.as_deref()
     }
 }
 

--- a/crates/libddwaf/src/config.rs
+++ b/crates/libddwaf/src/config.rs
@@ -7,7 +7,7 @@ pub struct Config {
     obfuscator: Obfuscator,
 }
 impl Config {
-    /// Creates a new [`Config`] with the provided [`Limits`] and [`Obfuscator`].
+    /// Creates a new [`Config`] with the provided [`Obfuscator`].
     #[must_use]
     pub fn new(obfuscator: Obfuscator) -> Self {
         Self { obfuscator }
@@ -18,12 +18,10 @@ impl Config {
         let mut map = WafMap::new(2);
         let mut used: u16 = 0;
         if let Some(key_regex) = self.obfuscator.key_regex() {
-            let key_regex: &[u8] = key_regex.as_ref();
             map[used as usize] = ("key_regex", key_regex).into();
             used += 1;
         }
         if let Some(value_regex) = self.obfuscator.value_regex() {
-            let value_regex: &[u8] = value_regex.as_ref();
             map[used as usize] = ("value_regex", value_regex).into();
             used += 1;
         }
@@ -62,15 +60,22 @@ impl Obfuscator {
     /// Returns the regular expression used to determine key data to be obfuscated, if one has been
     /// set.
     #[must_use]
-    pub const fn key_regex(&self) -> Option<&Vec<u8>> {
-        self.key_regex.as_ref()
+    pub const fn key_regex(&self) -> Option<&[u8]> {
+        // as_deref() is not const
+        match self.key_regex.as_ref() {
+            Some(v) => Some(v.as_slice()),
+            None => None,
+        }
     }
 
     /// Returns the regular expression used to determine value data to be obfuscated, if one has
     /// been set.
     #[must_use]
-    pub const fn value_regex(&self) -> Option<&Vec<u8>> {
-        self.value_regex.as_ref()
+    pub const fn value_regex(&self) -> Option<&[u8]> {
+        match self.value_regex.as_ref() {
+            Some(v) => Some(v.as_slice()),
+            None => None,
+        }
     }
 }
 

--- a/crates/libddwaf/src/config.rs
+++ b/crates/libddwaf/src/config.rs
@@ -1,43 +1,47 @@
-use std::ffi::{CStr, CString};
-use std::ptr::null_mut;
+use crate::object::WafMap;
+use crate::waf_map;
 
 /// The configuration for a new [`Builder`](crate::Builder).
-#[derive(Clone)]
+#[derive(Clone, Default, Debug)]
 pub struct Config {
-    pub(crate) raw: libddwaf_sys::ddwaf_config,
-    _obfuscator: Obfuscator, // For keeping the memory alive
+    obfuscator: Obfuscator,
 }
 impl Config {
     /// Creates a new [`Config`] with the provided [`Limits`] and [`Obfuscator`].
     #[must_use]
-    pub fn new(limits: Limits, obfuscator: Obfuscator) -> Self {
-        Self {
-            raw: libddwaf_sys::ddwaf_config {
-                limits,
-                obfuscator: obfuscator.raw,
-                free_fn: None,
-            },
-            _obfuscator: obfuscator,
-        }
+    pub fn new(obfuscator: Obfuscator) -> Self {
+        Self { obfuscator }
     }
-}
-impl Default for Config {
-    fn default() -> Self {
-        Self::new(Limits::default(), Obfuscator::default())
-    }
-}
 
-/// The limits attached to a [`Config`].
-pub type Limits = libddwaf_sys::_ddwaf_config__ddwaf_config_limits;
+    #[must_use]
+    pub fn as_waf_object(&self) -> WafMap {
+        let mut map = WafMap::new(2);
+        let mut used: u16 = 0;
+        if let Some(key_regex) = self.obfuscator.key_regex() {
+            let key_regex: &[u8] = key_regex.as_ref();
+            map[used as usize] = ("key_regex", key_regex).into();
+            used += 1;
+        }
+        if let Some(value_regex) = self.obfuscator.value_regex() {
+            let value_regex: &[u8] = value_regex.as_ref();
+            map[used as usize] = ("value_regex", value_regex).into();
+            used += 1;
+        }
+        map.truncate(used);
+
+        waf_map!(("obfuscator", map))
+    }
+}
 
 /// Obfuscation configuration for the WAF.
 ///
 /// This is effectively a pair of regular expressions that are respectively used
 /// to determine which key and value data to obfuscate when producing WAF
 /// outputs.
-#[repr(transparent)]
+#[derive(Clone, Debug)]
 pub struct Obfuscator {
-    raw: libddwaf_sys::_ddwaf_config__ddwaf_config_obfuscator,
+    key_regex: Option<Vec<u8>>,
+    value_regex: Option<Vec<u8>>,
 }
 impl Obfuscator {
     /// Creates a new [`Obfuscator`] with the provided key and value regular
@@ -49,51 +53,27 @@ impl Obfuscator {
         key_regex: Option<T>,
         value_regex: Option<U>,
     ) -> Self {
-        let key_regex = key_regex.map_or(null_mut(), |s| {
-            CString::new(s).expect("Invalid key regex").into_raw()
-        });
-        let value_regex = value_regex.map_or(null_mut(), |s| {
-            CString::new(s).expect("Invalid value regex").into_raw()
-        });
         Self {
-            #[allow(clippy::used_underscore_items)]
-            raw: libddwaf_sys::_ddwaf_config__ddwaf_config_obfuscator {
-                key_regex,
-                value_regex,
-            },
+            key_regex: key_regex.map(Into::into),
+            value_regex: value_regex.map(Into::into),
         }
     }
 
     /// Returns the regular expression used to determine key data to be obfuscated, if one has been
     /// set.
     #[must_use]
-    pub const fn key_regex(&self) -> Option<&CStr> {
-        if self.raw.key_regex.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(self.raw.key_regex) })
-        }
+    pub const fn key_regex(&self) -> Option<&Vec<u8>> {
+        self.key_regex.as_ref()
     }
 
     /// Returns the regular expression used to determine value data to be obfuscated, if one has
     /// been set.
     #[must_use]
-    pub const fn value_regex(&self) -> Option<&CStr> {
-        if self.raw.value_regex.is_null() {
-            None
-        } else {
-            Some(unsafe { CStr::from_ptr(self.raw.value_regex) })
-        }
+    pub const fn value_regex(&self) -> Option<&Vec<u8>> {
+        self.value_regex.as_ref()
     }
 }
-impl Clone for Obfuscator {
-    fn clone(&self) -> Self {
-        Self::new(
-            self.key_regex().map(CStr::to_bytes),
-            self.value_regex().map(CStr::to_bytes),
-        )
-    }
-}
+
 /// The regular expression used by [`Obfuscator::default`] to determine which key data to obfuscate.
 pub const OBFUSCATOR_DEFAULT_KEY_REGEX: &str = r"(?i)pass|pw(?:or)?d|secret|(?:api|private|public|access)[_-]?key|token|consumer[_-]?(?:id|key|secret)|sign(?:ed|ature)|bearer|authorization|jsessionid|phpsessid|asp\.net[_-]sessionid|sid|jwt";
 /// The regular expression used by [`Obfuscator::default`] to determine which value data to obfuscate.
@@ -104,19 +84,5 @@ impl Default for Obfuscator {
             Some(OBFUSCATOR_DEFAULT_KEY_REGEX),
             Some(OBFUSCATOR_DEFAULT_VAL_REGEX),
         )
-    }
-}
-impl Drop for Obfuscator {
-    fn drop(&mut self) {
-        if !self.raw.key_regex.is_null() {
-            unsafe {
-                drop(CString::from_raw(self.raw.key_regex.cast_mut()));
-            }
-        }
-        if !self.raw.value_regex.is_null() {
-            unsafe {
-                drop(CString::from_raw(self.raw.value_regex.cast_mut()));
-            }
-        }
     }
 }

--- a/crates/libddwaf/src/context.rs
+++ b/crates/libddwaf/src/context.rs
@@ -2,8 +2,9 @@ use std::error;
 use std::fmt;
 use std::time::Duration;
 
+use crate::object::WafOwnedOutputAllocator;
 use crate::object::get_default_allocator;
-use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject, WafOwned};
+use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject};
 
 /// A WAF Context that can be used to evaluate the configured ruleset against address data.
 ///
@@ -156,7 +157,7 @@ impl error::Error for RunError {}
 /// The data produced by a [`Context::run`] operation.
 #[repr(transparent)]
 pub struct RunOutput {
-    data: WafOwned<WafMap>,
+    data: WafOwnedOutputAllocator<WafMap>,
 }
 impl RunOutput {
     /// Returns true if the WAF did not have enough time to process all the address data that was

--- a/crates/libddwaf/src/context.rs
+++ b/crates/libddwaf/src/context.rs
@@ -2,8 +2,8 @@ use std::error;
 use std::fmt;
 use std::time::Duration;
 
-use crate::object::WafOwnedOutputAllocator;
 use crate::object::get_default_allocator;
+use crate::object::WafOwnedOutputAllocator;
 use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject};
 
 /// A WAF Context that can be used to evaluate the configured ruleset against address data.
@@ -13,9 +13,18 @@ use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject};
 pub struct Context {
     pub(crate) raw: libddwaf_sys::ddwaf_context,
 }
+
+/// Subcontexts are type of [`Context`] that inherit the data from their parents,
+/// but evaluations do not affect the parent's data.
+///
+/// Subcontexts can outlive their parent contexts.
+///
+/// They are obtained by calling [`Context::new_subcontext`][crate::Context::new_subcontext].
 pub struct Subcontext {
     pub(crate) raw: libddwaf_sys::ddwaf_subcontext,
 }
+
+/// Common waf evaluation interface for [`Context`] and [`Subcontext`].
 pub trait RunnableContext {
     /// Evaluates the configured ruleset against the provided address data, and returns the result
     /// of this evaluation.
@@ -85,10 +94,17 @@ impl RunnableContext for Context {
     }
 }
 impl Context {
-    #[must_use]
-    pub fn create_subcontext(&self) -> Subcontext {
-        Subcontext {
-            raw: unsafe { libddwaf_sys::ddwaf_subcontext_init(self.raw) },
+    /// Creates a new [`Subcontext`] from this [`Context`].
+    ///
+    /// # Errors
+    /// Returns an error if the WAF encountered an internal error while creating the subcontext.
+    /// This will not happen unless there is a bug in the WAF.
+    pub fn new_subcontext(&self) -> Result<Subcontext, InternalError> {
+        let raw = unsafe { libddwaf_sys::ddwaf_subcontext_init(self.raw) };
+        if raw.is_null() {
+            Err(InternalError {})
+        } else {
+            Ok(Subcontext { raw })
         }
     }
 }
@@ -122,7 +138,7 @@ unsafe impl Send for Subcontext {}
 /// Safety: The only method available takes an exclusive borrow.
 unsafe impl Sync for Subcontext {}
 
-/// The result of the [`Context::run`] operation.
+/// The result of the [`RunnableContext::run`] operation.
 #[derive(Debug)]
 pub enum RunResult {
     /// The WAF successfully processed the request, and produced no match.
@@ -132,7 +148,7 @@ pub enum RunResult {
     Match(RunOutput),
 }
 
-/// The error that can occur during a [`Context::run`] operation.
+/// The error that can occur during a [`RunnableContext::run`] operation.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum RunError {
@@ -153,6 +169,19 @@ impl fmt::Display for RunError {
     }
 }
 impl error::Error for RunError {}
+
+/// An unexpected internal error in the WAF from functions other than [`RunnableContext::run`].
+#[derive(Debug)]
+pub struct InternalError {}
+impl fmt::Display for InternalError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "An unexpected internal error occurred in the WAF; check the error logs"
+        )
+    }
+}
+impl error::Error for InternalError {}
 
 /// The data produced by a [`Context::run`] operation.
 #[repr(transparent)]

--- a/crates/libddwaf/src/context.rs
+++ b/crates/libddwaf/src/context.rs
@@ -1,8 +1,8 @@
 use std::error;
 use std::fmt;
-use std::ptr::null_mut;
 use std::time::Duration;
 
+use crate::object::get_default_allocator;
 use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject, WafOwned};
 
 /// A WAF Context that can be used to evaluate the configured ruleset against address data.
@@ -11,73 +11,89 @@ use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject, WafOwned
 /// be used to handle data for a single request.
 pub struct Context {
     pub(crate) raw: libddwaf_sys::ddwaf_context,
-    pub(crate) keepalive: Vec<WafMap>,
 }
-impl Context {
+pub struct Subcontext {
+    pub(crate) raw: libddwaf_sys::ddwaf_subcontext,
+}
+pub trait RunnableContext {
     /// Evaluates the configured ruleset against the provided address data, and returns the result
     /// of this evaluation.
     ///
     /// # Errors
     /// Returns an error if the WAF encountered an internal error, invalid object, or invalid argument while processing
     /// the request.
-    pub fn run(
-        &mut self,
-        mut persistent_data: Option<WafMap>,
-        ephemeral_data: Option<&WafMap>,
-        timeout: Duration,
-    ) -> Result<RunResult, RunError> {
-        let mut res = std::mem::MaybeUninit::<RunOutput>::uninit();
-        let persistent_ref = persistent_data
-            .as_mut()
-            // The bindings take non-const pointers to the data, but actually does not change it.
-            .map_or(null_mut(), |f| unsafe {
-                std::ptr::from_mut(f.as_raw_mut()).cast()
-            });
-        let ephemeral_ref = ephemeral_data
-            .map(AsRef::<libddwaf_sys::ddwaf_object>::as_ref)
-            // The bindings take non-const pointers to the data, but actually does not change it.
-            .map_or(null_mut(), |r| std::ptr::from_ref(r).cast_mut());
+    fn run(&mut self, data: WafMap, timeout: Duration) -> Result<RunResult, RunError>;
+}
 
-        let status = unsafe {
-            libddwaf_sys::ddwaf_run(
-                self.raw,
-                persistent_ref,
-                ephemeral_ref,
-                res.as_mut_ptr().cast(),
-                timeout.as_micros().try_into().unwrap_or(u64::MAX),
-            )
-        };
-        match status {
-            libddwaf_sys::DDWAF_ERR_INTERNAL => {
-                // It's unclear whether the persistent data needs to be kept alive or not, so we
-                // keep it alive to be on the safe side.
-                if let Some(obj) = persistent_data {
-                    self.keepalive.push(obj);
-                }
-                Err(RunError::InternalError)
-            }
-            libddwaf_sys::DDWAF_ERR_INVALID_OBJECT => Err(RunError::InvalidObject),
-            libddwaf_sys::DDWAF_ERR_INVALID_ARGUMENT => Err(RunError::InvalidArgument),
-            libddwaf_sys::DDWAF_OK => {
-                // We need to keep the persistent data alive as the WAF may hold references to it.
-                if let Some(obj) = persistent_data {
-                    self.keepalive.push(obj);
-                }
-                Ok(RunResult::NoMatch(unsafe { res.assume_init() }))
-            }
-            libddwaf_sys::DDWAF_MATCH => {
-                // We need to keep the persistent data alive as the WAF may hold references to it.
-                if let Some(obj) = persistent_data {
-                    self.keepalive.push(obj);
-                }
-                Ok(RunResult::Match(unsafe { res.assume_init() }))
-            }
-            unknown => unreachable!(
-                "Unexpected value returned by {}: 0x{:02X}",
-                stringify!(libddwaf_sys::ddwaf_run),
-                unknown
-            ),
+type RunFunc<S> = unsafe extern "C" fn(
+    S,
+    *mut libddwaf_sys::ddwaf_object,
+    libddwaf_sys::ddwaf_allocator,
+    *mut libddwaf_sys::ddwaf_object,
+    u64,
+) -> libddwaf_sys::DDWAF_RET_CODE;
+
+fn run<S>(
+    raw_self: S,
+    func: RunFunc<S>,
+    mut data: WafMap,
+    timeout: Duration,
+) -> Result<RunResult, RunError> {
+    let mut res = std::mem::MaybeUninit::<RunOutput>::uninit();
+
+    let data_ptr = unsafe { data.as_raw_mut() };
+
+    let status = unsafe {
+        func(
+            raw_self,
+            data_ptr,
+            get_default_allocator().into(),
+            res.as_mut_ptr().cast(),
+            timeout.as_micros().try_into().unwrap_or(u64::MAX),
+        )
+    };
+    match status {
+        libddwaf_sys::DDWAF_ERR_INTERNAL => {
+            // It's unclear whether the persistent data needs to be kept alive or not, so we
+            // keep it alive to be on the safe side.
+            std::mem::forget(data);
+            Err(RunError::InternalError)
         }
+        libddwaf_sys::DDWAF_ERR_INVALID_OBJECT => Err(RunError::InvalidObject),
+        libddwaf_sys::DDWAF_ERR_INVALID_ARGUMENT => Err(RunError::InvalidArgument),
+        libddwaf_sys::DDWAF_OK => {
+            // We need to keep the persistent data alive (now owned by the WAF)
+            std::mem::forget(data);
+            Ok(RunResult::NoMatch(unsafe { res.assume_init() }))
+        }
+        libddwaf_sys::DDWAF_MATCH => {
+            // We need to keep the persistent data alive (now owned by the WAF)
+            std::mem::forget(data);
+            Ok(RunResult::Match(unsafe { res.assume_init() }))
+        }
+        unknown => unreachable!(
+            "Unexpected value returned by {}: 0x{:02X}",
+            stringify!(libddwaf_sys::ddwaf_run),
+            unknown
+        ),
+    }
+}
+impl RunnableContext for Context {
+    fn run(&mut self, data: WafMap, timeout: Duration) -> Result<RunResult, RunError> {
+        run(self.raw, libddwaf_sys::ddwaf_context_eval, data, timeout)
+    }
+}
+impl Context {
+    #[must_use]
+    pub fn create_subcontext(&self) -> Subcontext {
+        Subcontext {
+            raw: unsafe { libddwaf_sys::ddwaf_subcontext_init(self.raw) },
+        }
+    }
+}
+impl RunnableContext for Subcontext {
+    fn run(&mut self, data: WafMap, timeout: Duration) -> Result<RunResult, RunError> {
+        run(self.raw, libddwaf_sys::ddwaf_subcontext_eval, data, timeout)
     }
 }
 impl Drop for Context {
@@ -85,11 +101,25 @@ impl Drop for Context {
         unsafe { libddwaf_sys::ddwaf_context_destroy(self.raw) }
     }
 }
-// Safety: Operations that mutate the internal state are made safe by requiring a mutable borrow on
-// the [Context] instance; and none of the internal state is exposed in any way.
+impl Drop for Subcontext {
+    fn drop(&mut self) {
+        unsafe { libddwaf_sys::ddwaf_subcontext_destroy(self.raw) }
+    }
+}
+
+/// Safety: [`Context`] is [`Send`] because it doesn't depend on thread local
+/// data and its pointer is not leaked or otherwise shared with other owning
+/// instances.
 unsafe impl Send for Context {}
-// Safety: [Context] is trivially [Sync] because it contains no methods allowing shared references.
+/// Safety: [`Context`] is [`Sync`] because having a shared reference does not
+/// allow for changing state (except for atomically increasing reference count
+/// of some elements in the context, like that of the context store)
 unsafe impl Sync for Context {}
+
+/// Safety: The same considerations apply to [`Subcontext`] as to [`Context`].
+unsafe impl Send for Subcontext {}
+/// Safety: The only method available takes an exclusive borrow.
+unsafe impl Sync for Subcontext {}
 
 /// The result of the [`Context::run`] operation.
 #[derive(Debug)]
@@ -135,7 +165,7 @@ impl RunOutput {
     pub fn timeout(&self) -> bool {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"timeout")
+            .get_bstr(b"timeout")
             .and_then(|o| o.to_bool())
             .unwrap_or_default()
     }
@@ -146,7 +176,7 @@ impl RunOutput {
     pub fn keep(&self) -> bool {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"keep")
+            .get_bstr(b"keep")
             .and_then(|o| o.to_bool())
             .unwrap_or_default()
     }
@@ -156,7 +186,7 @@ impl RunOutput {
     pub fn duration(&self) -> Duration {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"duration")
+            .get_bstr(b"duration")
             .and_then(|o| o.to_u64())
             .map(Duration::from_nanos)
             .unwrap_or_default()
@@ -168,7 +198,7 @@ impl RunOutput {
     pub fn events(&self) -> Option<&Keyed<WafArray>> {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"events")
+            .get_bstr(b"events")
             .and_then(Keyed::<WafObject>::as_type)
     }
 
@@ -178,7 +208,7 @@ impl RunOutput {
     pub fn actions(&self) -> Option<&Keyed<WafMap>> {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"actions")
+            .get_bstr(b"actions")
             .and_then(Keyed::<WafObject>::as_type)
     }
 
@@ -187,7 +217,7 @@ impl RunOutput {
     pub fn attributes(&self) -> Option<&Keyed<WafMap>> {
         debug_assert!(self.data.is_valid());
         self.data
-            .get(b"attributes")
+            .get_bstr(b"attributes")
             .and_then(Keyed::<WafObject>::as_type)
     }
 }

--- a/crates/libddwaf/src/handle.rs
+++ b/crates/libddwaf/src/handle.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use crate::Context;
+use crate::{Context, object::get_default_allocator};
 
 /// A fully configured WAF instance.
 ///
@@ -15,8 +15,9 @@ impl Handle {
     #[must_use]
     pub fn new_context(&self) -> Context {
         Context {
-            raw: unsafe { libddwaf_sys::ddwaf_context_init(self.raw) },
-            keepalive: Vec::new(),
+            raw: unsafe {
+                libddwaf_sys::ddwaf_context_init(self.raw, get_default_allocator().into())
+            },
         }
     }
 

--- a/crates/libddwaf/src/lib.rs
+++ b/crates/libddwaf/src/lib.rs
@@ -99,7 +99,7 @@ forward!(builder, config, context, handle);
 
 /// Returns the version of the underlying `libddwaf` library.
 #[must_use]
-pub fn get_version() -> &'static CStr {
+pub fn version() -> &'static CStr {
     let ptr = unsafe { libddwaf_sys::ddwaf_get_version() };
     if ptr.is_null() {
         unsafe { CStr::from_ptr("\0".as_ptr().cast()) }
@@ -112,8 +112,8 @@ pub fn get_version() -> &'static CStr {
 mod tests {
     #[test]
     #[cfg(not(miri))]
-    fn test_get_version() {
-        use crate::get_version;
+    fn test_version() {
+        use crate::version;
 
         if std::env::var("LIBDDWAF_PREFIX").is_ok() {
             eprintln!("Skipping test_get_version: LIBDDWAF_PREFIX is set");
@@ -122,7 +122,7 @@ mod tests {
 
         assert_eq!(
             env!("CARGO_PKG_VERSION"),
-            get_version()
+            version()
                 .to_str()
                 .expect("Failed to convert version to str")
         );

--- a/crates/libddwaf/src/lib.rs
+++ b/crates/libddwaf/src/lib.rs
@@ -89,7 +89,7 @@ macro_rules! forward {
     ($($name:ident),*) => {
         $(
             mod $name;
-            #[doc(inline = true)]
+            #[doc(inline)]
             pub use $name::*;
         )*
     };

--- a/crates/libddwaf/src/lib.rs
+++ b/crates/libddwaf/src/lib.rs
@@ -28,10 +28,11 @@
 //!     waf_map,
 //!     Builder,
 //!     Config,
+//!     RunnableContext,
 //!     RunResult,
 //! };
 //!
-//! let mut builder = Builder::new(&Config::default())
+//! let mut builder = Builder::new(Some(&Config::default()))
 //!     .expect("Failed to build WAF instance");
 //! let rule_set = waf_map!{
 //!     /* Typically obtained by parsing a rules file using the serde feature */
@@ -60,7 +61,7 @@
 //! let data = waf_map!{
 //!     ("arg1", "value1"),
 //! };
-//! match waf_ctx.run(Some(data), None, std::time::Duration::from_millis(1)) {
+//! match waf_ctx.run(data, std::time::Duration::from_millis(1)) {
 //!     // Deal with the result as appropriate...
 //!     Ok(RunResult::Match(res)) => {
 //!         assert!(!res.timeout());
@@ -113,6 +114,11 @@ mod tests {
 
     #[test]
     fn test_get_version() {
+        if std::env::var("LIBDDWAF_PREFIX").is_ok() {
+            eprintln!("Skipping test_get_version: LIBDDWAF_PREFIX is set");
+            return;
+        }
+
         assert_eq!(
             env!("CARGO_PKG_VERSION"),
             get_version()

--- a/crates/libddwaf/src/lib.rs
+++ b/crates/libddwaf/src/lib.rs
@@ -110,10 +110,11 @@ pub fn get_version() -> &'static CStr {
 
 #[cfg(test)]
 mod tests {
-    use crate::get_version;
-
     #[test]
+    #[cfg(not(miri))]
     fn test_get_version() {
+        use crate::get_version;
+
         if std::env::var("LIBDDWAF_PREFIX").is_ok() {
             eprintln!("Skipping test_get_version: LIBDDWAF_PREFIX is set");
             return;

--- a/crates/libddwaf/src/lib.rs
+++ b/crates/libddwaf/src/lib.rs
@@ -50,7 +50,7 @@
 //!         ("on_match", waf_array!{ "block" })
 //!     } }),
 //! };
-//! let mut diagnostics = WafOwned::<WafMap>::default();
+//! let mut diagnostics = WafOwnedDefaultAllocator::<WafMap>::default();
 //! if !builder.add_or_update_config("config/file/logical/path", &rule_set, Some(&mut diagnostics)) {
 //!     panic!("Failed to add or update config!");
 //! }

--- a/crates/libddwaf/src/object/iter.rs
+++ b/crates/libddwaf/src/object/iter.rs
@@ -1,15 +1,18 @@
 use std::alloc::Layout;
-use std::ptr::null_mut;
 
-use crate::object::{AsRawMutObject, Keyed, WafArray, WafMap, WafObject};
+use crate::object::{Keyed, WafArray, WafMap, WafObject};
 
 impl IntoIterator for WafArray {
     type Item = WafObject;
     type IntoIter = WafIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let array: *mut Self::Item = unsafe { self.raw.__bindgen_anon_1.array.cast() };
-        let len = if array.is_null() { 0 } else { self.len() };
+        let array: *mut Self::Item = unsafe { self.raw.via.array.ptr.cast() };
+        let len = if array.is_null() {
+            0
+        } else {
+            self.len() as usize
+        };
         // Forget about self, since the iterator is now the owner of the memory.
         std::mem::forget(self);
         WafIter { array, len, pos: 0 }
@@ -21,16 +24,7 @@ impl IntoIterator for Keyed<WafArray> {
     type IntoIter = WafIter<Self::Item>;
 
     fn into_iter(mut self) -> Self::IntoIter {
-        let mut arr = std::mem::take(&mut self.value);
-
-        // We're stopping the destructor from [`Keyed`] from running, so we need to explicitly
-        // drop the key from the value, or we'd be leaking it.
-        let raw_obj = unsafe { AsRawMutObject::as_raw_mut(&mut arr) };
-        unsafe { raw_obj.drop_key() };
-        raw_obj.parameterName = null_mut();
-        raw_obj.parameterNameLength = 0;
-
-        // Finally delegate back to the [`WafArray`] implementation.
+        let arr = std::mem::take(self.value_mut());
         arr.into_iter()
     }
 }
@@ -40,8 +34,12 @@ impl IntoIterator for WafMap {
     type IntoIter = WafIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let array: *mut Keyed<WafObject> = unsafe { self.raw.__bindgen_anon_1.array.cast() };
-        let len = if array.is_null() { 0 } else { self.len() };
+        let array: *mut Keyed<WafObject> = unsafe { self.raw.via.map.ptr.cast() };
+        let len = if array.is_null() {
+            0
+        } else {
+            self.len() as usize
+        };
         // Forget about self, since the iterator is now the owner of the memory.
         std::mem::forget(self);
         WafIter { array, len, pos: 0 }
@@ -53,16 +51,7 @@ impl IntoIterator for Keyed<WafMap> {
     type IntoIter = WafIter<Self::Item>;
 
     fn into_iter(mut self) -> Self::IntoIter {
-        let mut arr = std::mem::take(&mut self.value);
-
-        // We're stopping the destructor from [Keyed] from running, so we need to explicitly
-        // drop the key from the value, or we'd be leaking it.
-        let raw_obj = unsafe { AsRawMutObject::as_raw_mut(&mut arr) };
-        unsafe { raw_obj.drop_key() };
-        raw_obj.parameterName = null_mut();
-        raw_obj.parameterNameLength = 0;
-
-        // Finally delegate back to the [WafMap] implementation.
+        let arr = std::mem::take(self.value_mut());
         arr.into_iter()
     }
 }

--- a/crates/libddwaf/src/object/mod.rs
+++ b/crates/libddwaf/src/object/mod.rs
@@ -677,10 +677,7 @@ typed_object!(WafObjectType::String => WafString
             return None;
         }
 
-        const SMALL_STRING_SIZE: usize = {
-            let m = unsafe {std::mem::zeroed::<libddwaf_sys::_ddwaf_object_small_string>() };
-            std::mem::size_of_val(&m.data)
-        }; // 14
+        const SMALL_STRING_SIZE: usize = 14;
 
         if val.len() <= SMALL_STRING_SIZE {
             let mut ss = libddwaf_sys::_ddwaf_object_small_string {

--- a/crates/libddwaf/src/object/mod.rs
+++ b/crates/libddwaf/src/object/mod.rs
@@ -174,7 +174,7 @@ impl WafObject {
             return None;
         };
         if !unsafe {
-            let alloc = WafOwnedOutputAllocator::<Self>::get_allocator();
+            let alloc = WafOwnedOutputAllocator::<Self>::allocator();
             libddwaf_sys::ddwaf_object_from_json(
                 output.as_raw_mut(),
                 data.as_ptr().cast(),
@@ -408,8 +408,7 @@ impl From<&str> for WafObject {
 }
 impl From<&[u8]> for WafObject {
     fn from(value: &[u8]) -> Self {
-        let ws: WafString = value.into();
-        ws.into()
+        WafString::from(value).into()
     }
 }
 impl From<()> for WafObject {
@@ -436,13 +435,13 @@ impl crate::private::Sealed for WafObject {}
 /// Trait to encode which allocator should be used for deallocation in the type system.
 pub trait AllocatorType: 'static {
     /// Get the allocator to use for deallocation.
-    fn get_allocator() -> libddwaf_sys::ddwaf_allocator;
+    fn allocator() -> libddwaf_sys::ddwaf_allocator;
 }
 
-/// Allocator type that uses the system default allocator.
-pub struct SystemDefaultAllocator;
-impl AllocatorType for SystemDefaultAllocator {
-    fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
+/// Allocator type that uses libddwaf's default.
+pub struct LibddwafDefaultAllocator;
+impl AllocatorType for LibddwafDefaultAllocator {
+    fn allocator() -> libddwaf_sys::ddwaf_allocator {
         unsafe { libddwaf_sys::ddwaf_get_default_allocator() }
     }
 }
@@ -450,7 +449,7 @@ impl AllocatorType for SystemDefaultAllocator {
 /// Allocator type that uses the Rust-registered allocator.
 pub struct RustAllocator;
 impl AllocatorType for RustAllocator {
-    fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
+    fn allocator() -> libddwaf_sys::ddwaf_allocator {
         get_default_allocator().into()
     }
 }
@@ -465,8 +464,8 @@ pub struct WafOwned<T: AsRawMutObject, A: AllocatorType = RustAllocator> {
     _phantom: std::marker::PhantomData<A>,
 }
 impl<T: AsRawMutObject, A: AllocatorType> WafOwned<T, A> {
-    pub(crate) fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
-        A::get_allocator()
+    pub(crate) fn allocator() -> libddwaf_sys::ddwaf_allocator {
+        A::allocator()
     }
 }
 
@@ -497,7 +496,7 @@ impl<T: AsRawMutObject, A: AllocatorType> DerefMut for WafOwned<T, A> {
 impl<T: AsRawMutObject, A: AllocatorType> Drop for WafOwned<T, A> {
     fn drop(&mut self) {
         unsafe {
-            libddwaf_sys::ddwaf_object_destroy(self.inner.as_raw_mut(), A::get_allocator());
+            libddwaf_sys::ddwaf_object_destroy(self.inner.as_raw_mut(), A::allocator());
         }
     }
 }
@@ -511,7 +510,7 @@ where
 }
 
 /// Type alias for WAF-owned objects using the system default allocator.
-pub type WafOwnedDefaultAllocator<T> = WafOwned<T, SystemDefaultAllocator>;
+pub type WafOwnedDefaultAllocator<T> = WafOwned<T, LibddwafDefaultAllocator>;
 
 /// Type alias for WAF-owned objects using the Rust-registered allocator (for outputs).
 pub type WafOwnedOutputAllocator<T> = WafOwned<T, RustAllocator>;
@@ -807,7 +806,6 @@ typed_object!(WafObjectType::Array => WafArray {
     /// # Panics
     /// Panics if memory allocation fails (out of memory).
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn new(nb_entries: u16) -> Self {
         let size = usize::from(nb_entries);
         let layout = Layout::array::<libddwaf_sys::ddwaf_object>(size).unwrap();
@@ -817,6 +815,7 @@ typed_object!(WafObjectType::Array => WafArray {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     array: libddwaf_sys::_ddwaf_object_array {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_ARRAY as u8,
                         size: nb_entries,
                         capacity: nb_entries,
@@ -848,7 +847,12 @@ typed_object!(WafObjectType::Array => WafArray {
         unsafe { self.raw.via.array.capacity }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    /// Truncates this [`WafArray`] to the provided size.
+    ///
+    /// Has no effect is the current length is not greater than the new size.
+    ///
+    /// It does not free the extra memory, except insofar as it drops the extra elements.
+    /// Useful when you pessimistically allocate a larger array, but later discover that you don't need all the capacity.
     pub fn truncate(&mut self, new_size: u16) {
         if new_size > self.len() {
             return;
@@ -881,7 +885,6 @@ typed_object!(WafObjectType::Map => WafMap {
     /// # Panics
     /// Panics if memory allocation fails (out of memory).
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub fn new(nb_entries: u16) -> Self {
         let size = usize::from(nb_entries);
         let layout = Layout::array::<libddwaf_sys::_ddwaf_object_kv>(size).unwrap();
@@ -891,6 +894,7 @@ typed_object!(WafObjectType::Map => WafMap {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     map: libddwaf_sys::_ddwaf_object_map {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_MAP as u8,
                         size: nb_entries,
                         capacity: nb_entries,
@@ -922,6 +926,12 @@ typed_object!(WafObjectType::Map => WafMap {
         unsafe { self.raw.via.map.capacity }
     }
 
+    /// Truncates this [`WafMap`] to the provided size.
+    ///
+    /// Has no effect is the current length is not greater than the new size.
+    ///
+    /// It does not free the extra memory, except insofar as it drops the extra elements.
+    /// Useful when you pessimistically allocate a larger map, but later discover that you don't need all the capacity.
     pub fn truncate(&mut self, new_size: u16) {
         if new_size > self.len() {
             return;
@@ -995,12 +1005,12 @@ typed_object!(WafObjectType::Map => WafMap {
 typed_object!(WafObjectType::Bool => WafBool derive(Copy, Clone) {
     /// Creates a new [`WafBool`] with the provided value.
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub const fn new(val: bool) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     b8: libddwaf_sys::_ddwaf_object_bool {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_BOOL as u8,
                         val,
                     },
@@ -1019,12 +1029,12 @@ typed_object!(WafObjectType::Bool => WafBool derive(Copy, Clone) {
 typed_object!(WafObjectType::Float => WafFloat derive(Copy, Clone) {
     /// Creates a new [`WafFloat`] with the provided value.
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub const fn new(val: f64) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     f64_: libddwaf_sys::_ddwaf_object_float {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_FLOAT as u8,
                         val,
                     },
@@ -1043,12 +1053,12 @@ typed_object!(WafObjectType::Float => WafFloat derive(Copy, Clone) {
 typed_object!(WafObjectType::Null => WafNull derive(Copy, Clone) {
     /// Creates a new [`WafNull`].
     #[must_use]
-    #[allow(clippy::cast_possible_truncation)]
     pub const fn new() -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     u64_: libddwaf_sys::_ddwaf_object_unsigned {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_NULL as u8,
                         val: 0,
                     },
@@ -1118,21 +1128,25 @@ impl Drop for WafString {
     }
 }
 impl Clone for WafString {
-    #[allow(clippy::cast_possible_truncation)]
     fn clone(&self) -> Self {
         if self.raw.obj_type() == libddwaf_sys::DDWAF_OBJ_STRING {
-            let len = self.len() as usize;
-            let layout = Layout::array::<std::os::raw::c_char>(len).unwrap();
+            let len = self.len();
+            let layout = Layout::array::<std::os::raw::c_char>(len as usize).unwrap();
             let copied = unsafe { no_fail_alloc(layout).cast::<std::os::raw::c_char>() };
             unsafe {
-                std::ptr::copy_nonoverlapping(self.as_bytes().as_ptr().cast(), copied, len);
+                std::ptr::copy_nonoverlapping(
+                    self.as_bytes().as_ptr().cast(),
+                    copied,
+                    len as usize,
+                );
             }
             return Self {
                 raw: libddwaf_sys::ddwaf_object {
                     via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                         str_: libddwaf_sys::_ddwaf_object_string {
+                            #[allow(clippy::cast_possible_truncation)]
                             type_: libddwaf_sys::DDWAF_OBJ_STRING as u8,
-                            size: len as u32,
+                            size: len,
                             ptr: copied,
                         },
                     },
@@ -1184,7 +1198,6 @@ impl Drop for WafArray {
     }
 }
 impl Clone for WafArray {
-    #[allow(clippy::cast_possible_truncation)]
     fn clone(&self) -> Self {
         let size = self.len();
 
@@ -1207,6 +1220,7 @@ impl Clone for WafArray {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     array: libddwaf_sys::_ddwaf_object_array {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_ARRAY as u8,
                         size,
                         capacity: size,
@@ -1218,9 +1232,9 @@ impl Clone for WafArray {
     }
 }
 impl<T: Into<WafObject>, const N: usize> From<[T; N]> for WafArray {
-    #[allow(clippy::cast_possible_truncation)]
     fn from(value: [T; N]) -> Self {
         let effective_length = N.min(u16::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
         let mut array = Self::new(effective_length as u16);
         for (i, obj) in value.into_iter().enumerate() {
             if i >= effective_length {
@@ -1235,9 +1249,9 @@ impl<T> From<&mut [T]> for WafArray
 where
     T: Into<WafObject> + Default,
 {
-    #[allow(clippy::cast_possible_truncation)]
     fn from(value: &mut [T]) -> Self {
         let effective_length = value.len().min(u16::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
         let mut array = Self::new(effective_length as u16);
         for (i, obj) in value.iter_mut().enumerate() {
             if i >= effective_length {
@@ -1306,7 +1320,6 @@ impl Drop for WafMap {
     }
 }
 impl Clone for WafMap {
-    #[allow(clippy::cast_possible_truncation)]
     fn clone(&self) -> Self {
         let size = self.len();
 
@@ -1329,6 +1342,7 @@ impl Clone for WafMap {
             raw: libddwaf_sys::ddwaf_object {
                 via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
                     map: libddwaf_sys::_ddwaf_object_map {
+                        #[allow(clippy::cast_possible_truncation)]
                         type_: libddwaf_sys::DDWAF_OBJ_MAP as u8,
                         size,
                         capacity: size,
@@ -1357,9 +1371,9 @@ impl IndexMut<usize> for WafMap {
     }
 }
 impl<K: AsRef<[u8]>, V: Into<WafObject>, const N: usize> From<[(K, V); N]> for WafMap {
-    #[allow(clippy::cast_possible_truncation)]
     fn from(vals: [(K, V); N]) -> Self {
         let effective_length = N.min(u16::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
         let mut map = WafMap::new(effective_length as u16);
         for (i, (k, v)) in vals.into_iter().enumerate() {
             if i >= effective_length {
@@ -1371,9 +1385,9 @@ impl<K: AsRef<[u8]>, V: Into<WafObject>, const N: usize> From<[(K, V); N]> for W
     }
 }
 impl<V: Into<WafObject>, const N: usize> From<[(WafObject, V); N]> for WafMap {
-    #[allow(clippy::cast_possible_truncation)]
     fn from(vals: [(WafObject, V); N]) -> Self {
         let effective_length = N.min(u16::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
         let mut map = WafMap::new(effective_length as u16);
         for (i, (k, v)) in vals.into_iter().enumerate() {
             if i >= effective_length {
@@ -1389,9 +1403,9 @@ where
     K: Into<WafObject> + Default,
     V: Into<WafObject> + Default,
 {
-    #[allow(clippy::cast_possible_truncation)]
     fn from(value: &mut [(K, V)]) -> Self {
         let effective_length = value.len().min(u16::MAX as usize);
+        #[allow(clippy::cast_possible_truncation)]
         let mut map = Self::new(effective_length as u16);
         for (i, (k, v)) in value.iter_mut().enumerate() {
             if i >= effective_length {
@@ -1489,14 +1503,14 @@ impl<T: AsRawMutObject> Keyed<T> {
     /// [`std::str::from_utf8`] or if the key is not a [`WafString`].
     #[allow(invalid_from_utf8)]
     pub fn key_str(&self) -> Result<&str, Box<dyn std::error::Error>> {
-        std::str::from_utf8(self.key_bstr()?).map_err(std::convert::Into::into)
+        std::str::from_utf8(self.key_bytes()?).map_err(std::convert::Into::into)
     }
 
     /// Obtains the key associated with this [`Keyed<WafObject>`] as a byte slice.
     ///
     /// # Errors
     /// Returns an error if the underlying key data is not a [`WafString`].
-    pub fn key_bstr(&self) -> Result<&[u8], ObjectTypeError> {
+    pub fn key_bytes(&self) -> Result<&[u8], ObjectTypeError> {
         let key = self.key();
         match key.as_type::<WafString>() {
             Some(s) => Ok(s.as_bytes()),
@@ -1516,16 +1530,15 @@ impl<T: AsRawMutObject> Keyed<T> {
 
     /// Sets the key associated with this [`Keyed<WafObject>`].
     /// If the key is longer than `u32::MAX` bytes, it will be truncated.
-    pub fn set_key_bstr(&mut self, key: &[u8]) -> &mut Self {
+    pub fn set_key_bytes(&mut self, key: &[u8]) -> &mut Self {
         let key = WafString::from(key);
         self.set_key(key)
     }
 
     /// Sets the key associated with this [`Keyed<WafObject>`] to the provided string.
     /// If the key is longer than `u32::MAX` bytes, it will be truncated.
-    pub fn set_key_str(&mut self, key: &str) -> &mut Self {
-        let key = WafString::from(key);
-        self.set_key(key)
+    pub fn set_key_str(&mut self, key: impl Into<WafString>) -> &mut Self {
+        self.set_key(key.into())
     }
 }
 impl Keyed<WafObject> {

--- a/crates/libddwaf/src/object/mod.rs
+++ b/crates/libddwaf/src/object/mod.rs
@@ -1,8 +1,10 @@
 #![doc = "Data model for exchanging data with the in-app WAF."]
 
 use std::alloc::Layout;
+use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut, Index, IndexMut};
 use std::ptr::null_mut;
+use std::sync::OnceLock;
 use std::{cmp, fmt};
 
 mod iter;
@@ -24,7 +26,7 @@ pub enum WafObjectType {
     String,
     /// An array of [`WafObject`]s.
     Array,
-    /// A map of string-keyed [`WafObject`]s.
+    /// An array of [`Keyed<WafObject>`]s.
     Map,
     /// A boolean value.
     Bool,
@@ -56,7 +58,9 @@ impl TryFrom<libddwaf_sys::DDWAF_OBJ_TYPE> for WafObjectType {
             libddwaf_sys::DDWAF_OBJ_INVALID => Ok(WafObjectType::Invalid),
             libddwaf_sys::DDWAF_OBJ_SIGNED => Ok(WafObjectType::Signed),
             libddwaf_sys::DDWAF_OBJ_UNSIGNED => Ok(WafObjectType::Unsigned),
-            libddwaf_sys::DDWAF_OBJ_STRING => Ok(WafObjectType::String),
+            libddwaf_sys::DDWAF_OBJ_STRING
+            | libddwaf_sys::DDWAF_OBJ_LITERAL_STRING
+            | libddwaf_sys::DDWAF_OBJ_SMALL_STRING => Ok(WafObjectType::String),
             libddwaf_sys::DDWAF_OBJ_ARRAY => Ok(WafObjectType::Array),
             libddwaf_sys::DDWAF_OBJ_MAP => Ok(WafObjectType::Map),
             libddwaf_sys::DDWAF_OBJ_BOOL => Ok(WafObjectType::Bool),
@@ -90,6 +94,27 @@ impl std::fmt::Display for ObjectTypeError {
             f,
             "Invalid object type (expected {:?}, got {:?})",
             self.expected, self.actual
+        )
+    }
+}
+
+/// The error that is returned when a value's length exceeds the maximum allowed.
+///
+/// This applies to strings (max [`u32::MAX`]) and arrays/maps (max [`u16::MAX`]).
+#[derive(Copy, Clone, Debug)]
+pub struct LengthTooLargeError {
+    /// The length that was too large.
+    pub length: usize,
+    /// The maximum allowed length.
+    pub max_length: usize,
+}
+impl std::error::Error for LengthTooLargeError {}
+impl std::fmt::Display for LengthTooLargeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Length {} exceeds maximum allowed {}",
+            self.length, self.max_length
         )
     }
 }
@@ -149,7 +174,12 @@ impl WafObject {
             return None;
         };
         if !unsafe {
-            libddwaf_sys::ddwaf_object_from_json(obj.as_raw_mut(), data.as_ptr().cast(), len)
+            libddwaf_sys::ddwaf_object_from_json(
+                obj.as_raw_mut(),
+                data.as_ptr().cast(),
+                len,
+                get_default_allocator().into(),
+            )
         } {
             return None;
         }
@@ -163,7 +193,7 @@ impl WafObject {
     #[must_use]
     pub fn get_type(&self) -> WafObjectType {
         self.as_ref()
-            .type_
+            .obj_type()
             .try_into()
             .unwrap_or(WafObjectType::Invalid)
     }
@@ -298,6 +328,48 @@ impl Drop for WafObject {
         unsafe { self.raw.drop_object() }
     }
 }
+impl Clone for WafObject {
+    fn clone(&self) -> Self {
+        match self.get_type() {
+            WafObjectType::Invalid => {
+                let obj: &WafInvalid = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::Signed => {
+                let obj: &WafSigned = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::Unsigned => {
+                let obj: &WafUnsigned = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::Bool => {
+                let obj: &WafBool = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::Float => {
+                let obj: &WafFloat = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::Null => {
+                let obj: &WafNull = unsafe { self.as_type_unchecked() };
+                (*obj).into()
+            }
+            WafObjectType::String => {
+                let obj: &WafString = unsafe { self.as_type_unchecked() };
+                obj.clone().into()
+            }
+            WafObjectType::Array => {
+                let obj: &WafArray = unsafe { self.as_type_unchecked() };
+                obj.clone().into()
+            }
+            WafObjectType::Map => {
+                let obj: &WafMap = unsafe { self.as_type_unchecked() };
+                obj.clone().into()
+            }
+        }
+    }
+}
 impl From<u64> for WafObject {
     fn from(value: u64) -> Self {
         WafUnsigned::new(value).into()
@@ -330,12 +402,13 @@ impl From<bool> for WafObject {
 }
 impl From<&str> for WafObject {
     fn from(value: &str) -> Self {
-        WafString::new(value).into()
+        value.as_bytes().into()
     }
 }
 impl From<&[u8]> for WafObject {
     fn from(value: &[u8]) -> Self {
-        WafString::new(value).into()
+        let ws: WafString = value.into();
+        ws.into()
     }
 }
 impl From<()> for WafObject {
@@ -390,7 +463,13 @@ impl<T: AsRawMutObject> DerefMut for WafOwned<T> {
 }
 impl<T: AsRawMutObject> Drop for WafOwned<T> {
     fn drop(&mut self) {
-        unsafe { libddwaf_sys::ddwaf_object_free(self.inner.as_raw_mut()) };
+        unsafe {
+            libddwaf_sys::ddwaf_object_destroy(
+                self.inner.as_raw_mut(),
+                // we use this allocator in `Handle::new_context`
+                get_default_allocator().into(),
+            );
+        }
     }
 }
 impl<T: AsRawMutObject> PartialEq<T> for WafOwned<T>
@@ -419,18 +498,27 @@ unsafe fn no_fail_alloc(layout: Layout) -> *mut u8 {
 }
 
 macro_rules! typed_object {
-    ($type:expr => $name:ident $({ $($impl:tt)* })?) => {
+    (@defaults $type:expr, $name:ident) => {
+        #[doc = concat!("Returns true if this [", stringify!($name), "] is indeed [", stringify!($type), "].")]
+        #[must_use]
+        pub fn is_valid(&self) -> bool {
+            self.raw.obj_type() == $type.as_raw()
+        }
+    };
+    (@defaults $type:expr, $name:ident, $($is_valid:tt)*) => {
+        #[doc = concat!("Returns true if this [", stringify!($name), "] is indeed [", stringify!($type), "].")]
+        #[must_use]
+        $($is_valid)*
+    };
+    ($type:expr => $name:ident $(derive($($derives:ident),* $(,)?))? $(is_valid { $($is_valid:tt)* })? $({ $($impl:tt)* })?) => {
         #[doc = concat!("The WAF object representation of a value of type [", stringify!($type), "]")]
         #[repr(transparent)]
+        $(#[derive($($derives),*)] )?
         pub struct $name {
             raw: libddwaf_sys::ddwaf_object,
         }
         impl $name {
-            #[doc = concat!("Returns true if this [", stringify!($name), "] is indeed [", stringify!($type), "].")]
-            #[must_use]
-            pub const fn is_valid(&self) -> bool {
-                self.raw.type_ == $type.as_raw()
-            }
+            typed_object!(@defaults $type, $name $(, $($is_valid)*)?);
 
             /// Returns a reference to this value as a [`WafObject`].
             #[must_use]
@@ -452,13 +540,12 @@ macro_rules! typed_object {
             }
         }
         impl Default for $name {
+            #[allow(clippy::cast_possible_truncation)]
             fn default() -> Self {
-                Self {
-                    raw: libddwaf_sys::ddwaf_object {
-                        type_: $type.as_raw(),
-                        ..Default::default()
-                    },
-                }
+                // All the types admit this representation
+                let mut raw: libddwaf_sys::ddwaf_object = unsafe { std::mem::zeroed() };
+                raw.type_ = $type.as_raw() as u8;
+                Self { raw }
             }
         }
         impl TryFrom<WafObject> for $name {
@@ -487,19 +574,21 @@ macro_rules! typed_object {
     };
 }
 
-typed_object!(WafObjectType::Invalid => WafInvalid);
-typed_object!(WafObjectType::Signed => WafSigned {
+typed_object!(WafObjectType::Invalid => WafInvalid derive(Copy, Clone));
+
+typed_object!(WafObjectType::Signed => WafSigned derive(Copy, Clone) {
     /// Creates a new [`WafSigned`] with the provided value.
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn new(val: i64) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_SIGNED,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { intValue: val },
-                nbEntries: 0,
-                parameterName: null_mut(),
-                parameterNameLength: 0,
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    i64_: libddwaf_sys::_ddwaf_object_signed {
+                        type_: libddwaf_sys::DDWAF_OBJ_SIGNED as u8,
+                        val,
+                    },
+                },
             }
         }
     }
@@ -507,84 +596,163 @@ typed_object!(WafObjectType::Signed => WafSigned {
     /// Returns the value of this [`WafSigned`].
     #[must_use]
     pub const fn value(&self) -> i64 {
-        unsafe { self.raw.__bindgen_anon_1.intValue }
+        unsafe { self.raw.via.i64_.val }
     }
 });
-typed_object!(WafObjectType::Unsigned => WafUnsigned {
+
+typed_object!(WafObjectType::Unsigned => WafUnsigned derive(Copy, Clone) {
     /// Creates a new [`WafUnsigned`] with the provided value.
     #[must_use]
-    pub const fn new (val: u64) -> Self {
+    #[allow(clippy::cast_possible_truncation)]
+    pub const fn new(val: u64) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_UNSIGNED,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { uintValue: val },
-                nbEntries: 0,
-                parameterName: null_mut(),
-                parameterNameLength: 0,
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    u64_: libddwaf_sys::_ddwaf_object_unsigned {
+                        type_: libddwaf_sys::DDWAF_OBJ_UNSIGNED as u8,
+                        val,
+                    },
+                },
             }
         }
     }
 
-    /// Retuns the value of this [`WafUnsigned`].
+    /// Returns the value of this [`WafUnsigned`].
     #[must_use]
     pub const fn value(&self) -> u64 {
-        unsafe { self.raw.__bindgen_anon_1.uintValue }
+        unsafe { self.raw.via.u64_.val }
     }
 });
-typed_object!(WafObjectType::String => WafString {
+
+typed_object!(WafObjectType::String => WafString
+    is_valid {
+        pub fn is_valid(&self) -> bool {
+            self.raw.obj_type() & libddwaf_sys::DDWAF_OBJ_STRING != 0
+        }
+    }
+    {
     /// Creates a new [`WafString`] with the provided value.
-    pub fn new(val: impl AsRef<[u8]>) -> Self {
+    /// Only returns none if the string is larger than [`u32::MAX`] bytes.
+    ///
+    /// # Panics
+    /// Panics if memory allocation fails (out of memory).
+    #[allow(clippy::cast_possible_truncation, clippy::items_after_statements)]
+    pub fn new(val: impl AsRef<[u8]>) -> Option<Self> {
         let val = val.as_ref();
-        let ptr = if val.is_empty() {
+        if val.len() > (u32::MAX as usize) {
+            return None;
+        }
+
+        const SMALL_STRING_SIZE: usize = {
+            let m = unsafe {std::mem::zeroed::<libddwaf_sys::_ddwaf_object_small_string>() };
+            std::mem::size_of_val(&m.data)
+        }; // 14
+
+        if val.len() <= SMALL_STRING_SIZE {
+            let mut ss = libddwaf_sys::_ddwaf_object_small_string {
+                type_: libddwaf_sys::DDWAF_OBJ_SMALL_STRING as u8,
+                size: val.len() as u8,
+                data: [0; 14],
+            };
+            let valcast = unsafe {
+                std::slice::from_raw_parts(val.as_ptr().cast(), val.len())
+            };
+            ss.data[..valcast.len()].copy_from_slice(valcast);
+
+            return Some(Self {
+                raw: libddwaf_sys::ddwaf_object {
+                    via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                        sstr: ss,
+                    },
+                },
+            })
+        }
+
+        let ptr: *mut ::std::os::raw::c_char = if val.is_empty() {
             null_mut()
         } else {
-            let b: Box<[u8]> = val.into();
-            Box::into_raw(b).cast()
+            unsafe { no_fail_alloc(Layout::array::<::std::os::raw::c_char>(val.len()).unwrap()).cast() }
         };
+        unsafe {
+            std::ptr::copy_nonoverlapping(val.as_ptr(), ptr.cast(), val.len());
+        }
+        Some(Self {
+            raw: libddwaf_sys::ddwaf_object {
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    str_: libddwaf_sys::_ddwaf_object_string {
+                        type_: libddwaf_sys::DDWAF_OBJ_STRING as u8,
+                        size: val.len() as u32,
+                        ptr,
+                    },
+                },
+            },
+        })
+    }
+
+    /// Creates a new [`WafString`] with the provided static value.
+    ///
+    /// # Panics
+    /// Panics if the string is larger than [`u32::MAX`] bytes.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new_literal(val: impl Into<&'static [u8]>) -> Self {
+        let val = val.into();
+        let len = u32::try_from(val.len()).expect("string is too large for this platform");
+
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_STRING,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
-                    stringValue: ptr,
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    str_: libddwaf_sys::_ddwaf_object_string {
+                        type_: libddwaf_sys::DDWAF_OBJ_LITERAL_STRING as u8,
+                        size: len,
+                        ptr: val.as_ptr() as *mut _,
+                    },
                 },
-                nbEntries: val.len() as u64,
-                ..Default::default()
             },
         }
+
     }
 
     /// Returns the length of this [`WafString`], in bytes.
-    ///
-    /// # Panics
-    /// Panics if the string is larger than [`usize::MAX`] bytes. This can only happen on
-    /// platforms where [`usize`] is 32-bit wide.
     #[must_use]
-    pub fn len(&self) -> usize {
-        usize::try_from(self.raw.nbEntries).expect("string is too large for this platform")
+    pub fn len(&self) -> u32 {
+        if self.raw.obj_type() == libddwaf_sys::DDWAF_OBJ_SMALL_STRING {
+            u32::from(unsafe { self.raw.via.sstr.size })
+        } else {
+            unsafe { self.raw.via.str_.size }
+        }
     }
 
     /// Returns true if this [`WafString`] is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.len() == 0u32
     }
 
     /// Returns a slice of the bytes from this [`WafString`].
     #[must_use]
-    pub fn bytes(&self) -> &[u8] {
-        debug_assert_eq!(self.raw.type_, libddwaf_sys::DDWAF_OBJ_STRING);
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn as_bytes(&self) -> &[u8] {
+        debug_assert!(self.is_valid());
         let len = self.len();
         if len == 0 {
             return &[];
         }
-        debug_assert!(!unsafe{ self.raw.__bindgen_anon_1.stringValue }.is_null());
-        unsafe {
-            std::slice::from_raw_parts(
-                self.raw.__bindgen_anon_1.stringValue.cast(),
-                len,
-            )
+
+        if self.raw.obj_type() == libddwaf_sys::DDWAF_OBJ_SMALL_STRING {
+            unsafe {
+                std::slice::from_raw_parts(
+                    self.raw.via.sstr.data.as_ptr().cast(),
+                    len as usize,
+                )
+            }
+        } else {
+            debug_assert!(!unsafe{ self.raw.via.str_.ptr }.is_null());
+            unsafe {
+                std::slice::from_raw_parts(
+                    self.raw.via.str_.ptr.cast(),
+                    len as usize,
+                )
+            }
         }
     }
 
@@ -594,7 +762,7 @@ typed_object!(WafObjectType::String => WafString {
     /// Returns an error if the underlying data is not a valid UTF-8 string, under the same conditions as
     /// [`std::str::from_utf8`].
     pub fn as_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(self.bytes())
+        std::str::from_utf8(self.as_bytes())
     }
 });
 typed_object!(WafObjectType::Array => WafArray {
@@ -602,39 +770,61 @@ typed_object!(WafObjectType::Array => WafArray {
     /// to an invalid [`WafObject`] instance.
     ///
     /// # Panics
-    /// Panics when the provided `nb_entries` is larger than what the current platform can represent in an [`usize`].
-    /// This can only happen on platforms where [`usize`] is 32-bit wide.
+    /// Panics if memory allocation fails (out of memory).
     #[must_use]
-    pub fn new(nb_entries: u64) -> Self {
-        let size = usize::try_from(nb_entries).expect("size is too large for this platform");
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(nb_entries: u16) -> Self {
+        let size = usize::from(nb_entries);
         let layout = Layout::array::<libddwaf_sys::ddwaf_object>(size).unwrap();
-        let array = unsafe { no_fail_alloc(layout).cast() };
-        unsafe { std::ptr::write_bytes(array, 0, size)};
+        let ptr = unsafe { no_fail_alloc(layout).cast() };
+        unsafe { std::ptr::write_bytes(ptr, 0, size)};
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_ARRAY,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { array },
-                nbEntries: nb_entries,
-                ..Default::default()
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    array: libddwaf_sys::_ddwaf_object_array {
+                        type_: libddwaf_sys::DDWAF_OBJ_ARRAY as u8,
+                        size: nb_entries,
+                        capacity: nb_entries,
+                        ptr,
+                    },
+                },
             }
         }
     }
 
     /// Returns the length of this [`WafArray`].
-    ///
-    /// # Panics
-    /// Panics if the array is larger than [`usize::MAX`] elements. This can only happen on
-    /// platforms where [`usize`] is 32-bit wide.
     #[must_use]
-    pub fn len(&self) -> usize {
-        usize::try_from(self.raw.nbEntries).expect("array is too large for this platform")
+    pub const fn len(&self) -> u16 {
+        unsafe { self.raw.via.array.size }
     }
 
     /// Returns true if this [`WafArray`] is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Returns the capacity of this [`WafArray`].
+    ///
+    /// The capacity is an implementation detail and is only used to for properly
+    /// deallocating the memory when the array is dropped.
+    #[must_use]
+    pub const fn capacity(&self) -> u16 {
+        unsafe { self.raw.via.array.capacity }
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn truncate(&mut self, new_size: u16) {
+        if new_size > self.len() {
+            return;
+        }
+        let arr: *mut WafObject = unsafe { self.raw.via.array.ptr.cast() };
+        for i in new_size..self.len() {
+            unsafe {
+                std::ptr::drop_in_place(arr.add(i as usize));
+            }
+        }
+        self.raw.via.array.size = new_size;
     }
 
     /// Returns an iterator over the [`Keyed<WafObject>`]s in this [`WafMap`].
@@ -654,39 +844,60 @@ typed_object!(WafObjectType::Map => WafMap {
     /// to an invalid [`WafObject`] instance with a blank key.
     ///
     /// # Panics
-    /// Panics when the provided `nbEntries` is larger than what the current platform can represent in an [`usize`].
-    /// This can only happen on platforms where [`usize`] is 32-bit wide.
+    /// Panics if memory allocation fails (out of memory).
     #[must_use]
-    pub fn new(nb_entries: u64) -> Self {
-        let size = usize::try_from(nb_entries).expect("size is too large for this platform");
-        let layout = Layout::array::<libddwaf_sys::ddwaf_object>(size).unwrap();
-        let array = unsafe { no_fail_alloc(layout).cast() };
-        unsafe { std::ptr::write_bytes(array, 0, size)};
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(nb_entries: u16) -> Self {
+        let size = usize::from(nb_entries);
+        let layout = Layout::array::<libddwaf_sys::_ddwaf_object_kv>(size).unwrap();
+        let ptr = unsafe { no_fail_alloc(layout).cast() };
+        unsafe { std::ptr::write_bytes(ptr, 0, size)};
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_MAP,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {  array },
-                nbEntries: nb_entries,
-                ..Default::default()
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    map: libddwaf_sys::_ddwaf_object_map {
+                        type_: libddwaf_sys::DDWAF_OBJ_MAP as u8,
+                        size: nb_entries,
+                        capacity: nb_entries,
+                        ptr,
+                    },
+                },
             }
         }
     }
 
     /// Returns the length of this [`WafMap`].
-    ///
-    /// # Panics
-    /// Panics if the map is larger than [`usize::MAX`] elements. This can only happen on platforms
-    /// where [`usize`] is 32-bit wide.
     #[must_use]
-    pub fn len(&self) -> usize {
-        usize::try_from(self.raw.nbEntries).expect("map is too large for this platform")
+    pub const fn len(&self) -> u16 {
+        unsafe { self.raw.via.map.size }
     }
 
     /// Returns true if this [`WafMap`] is empty.
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Returns the capacity of this [`WafMap`].
+    ///
+    /// The capacity is an implementation detail and is only used to for properly
+    /// deallocating the memory when the map is dropped.
+    #[must_use]
+    pub const fn capacity(&self) -> u16 {
+        unsafe { self.raw.via.map.capacity }
+    }
+
+    pub fn truncate(&mut self, new_size: u16) {
+        if new_size > self.len() {
+            return;
+        }
+        let entries: *mut Keyed<WafObject> = unsafe { self.raw.via.map.ptr.cast() };
+        for i in new_size..self.len() {
+            unsafe {
+                std::ptr::drop_in_place(entries.add(i as usize));
+            }
+        }
+        self.raw.via.map.size = new_size;
     }
 
     /// Returns an iterator over the [`Keyed<WafObject>`]s in this [`WafMap`].
@@ -705,31 +916,40 @@ typed_object!(WafObjectType::Map => WafMap {
     ///
     /// If multiple such objects exist in the receiver, the first match is returned.
     #[must_use]
-    pub fn get(&self, key: &'_ [u8]) -> Option<&Keyed<WafObject>> {
-        for o in self.iter() {
-            if o.key() == key {
-                return Some(o)
+    pub fn get(&self, key: impl AsRef<libddwaf_sys::ddwaf_object>) -> Option<&Keyed<WafObject>> {
+        let key = key.as_ref();
+        self.iter().find(|o| o.key().raw.eq(key))
+    }
+
+    /// Returns a reference to the [`Keyed<WafObject>`] with the provided key, if one exists.
+    ///
+    /// If multiple such objects exist in the receiver, the first match is returned.
+    #[must_use]
+    pub fn get_bstr(&self, key: &'_ [u8]) -> Option<&Keyed<WafObject>> {
+        self.iter().find(|o| {
+            match o.key().as_type::<WafString>() {
+                Some(s) => s.as_bytes() == key,
+                None => false,
             }
-        }
-        None
+        })
     }
 
     /// Returns a mutable reference to the [`Keyed<WafObject>`] with the provided key, if one exists.
     ///
     /// If multiple such objects exist in the receiver, the first match is returned.
     pub fn get_mut(&mut self, key: &'_ [u8]) -> Option<&mut Keyed<WafObject>> {
-        for o in self.iter_mut() {
-            if o.key() == key {
-                return Some(o)
+        self.iter_mut().find(|o| {
+            match o.key().as_type::<WafString>() {
+                Some(s) => s.as_bytes() == key,
+                None => false
             }
-        }
-        None
+        })
     }
 
     /// Returns a reference to the [`Keyed<WafObject>`] with the provided key, if one exists.
     #[must_use]
     pub fn get_str(&self, key: &'_ str) -> Option<&Keyed<WafObject>> {
-        self.get(key.as_bytes())
+        self.get_bstr(key.as_bytes())
     }
 
     /// Returns a mutable reference to the [`Keyed<WafObject>`] with the provided key, if one exists.
@@ -737,18 +957,19 @@ typed_object!(WafObjectType::Map => WafMap {
         self.get_mut(key.as_bytes())
     }
 });
-typed_object!(WafObjectType::Bool => WafBool {
+typed_object!(WafObjectType::Bool => WafBool derive(Copy, Clone) {
     /// Creates a new [`WafBool`] with the provided value.
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn new(val: bool) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_BOOL,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { boolean: val },
-                nbEntries: 0,
-                parameterName: null_mut(),
-                parameterNameLength: 0,
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    b8: libddwaf_sys::_ddwaf_object_bool {
+                        type_: libddwaf_sys::DDWAF_OBJ_BOOL as u8,
+                        val,
+                    },
+                },
             }
         }
     }
@@ -756,21 +977,23 @@ typed_object!(WafObjectType::Bool => WafBool {
     /// Returns the value of this [`WafBool`].
     #[must_use]
     pub const fn value(&self) -> bool {
-        unsafe { self.raw.__bindgen_anon_1.boolean }
+        unsafe { self.raw.via.b8.val }
     }
 });
-typed_object!(WafObjectType::Float => WafFloat {
+
+typed_object!(WafObjectType::Float => WafFloat derive(Copy, Clone) {
     /// Creates a new [`WafFloat`] with the provided value.
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn new(val: f64) -> Self {
         Self {
             raw: libddwaf_sys::ddwaf_object {
-                type_: libddwaf_sys::DDWAF_OBJ_FLOAT,
-                #[allow(clippy::used_underscore_items)]
-                __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { f64_: val },
-                nbEntries: 0,
-                parameterName: null_mut(),
-                parameterNameLength: 0,
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    f64_: libddwaf_sys::_ddwaf_object_float {
+                        type_: libddwaf_sys::DDWAF_OBJ_FLOAT as u8,
+                        val,
+                    },
+                },
             }
         }
     }
@@ -778,23 +1001,28 @@ typed_object!(WafObjectType::Float => WafFloat {
     /// Returns the value of this [`WafFloat`].
     #[must_use]
     pub const fn value(&self) -> f64 {
-        unsafe { self.raw.__bindgen_anon_1.f64_ }
+        unsafe { self.raw.via.f64_.val }
     }
 });
-typed_object!(WafObjectType::Null => WafNull {
+
+typed_object!(WafObjectType::Null => WafNull derive(Copy, Clone) {
     /// Creates a new [`WafNull`].
     #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
     pub const fn new() -> Self {
-        Self { raw: libddwaf_sys::ddwaf_object {
-            type_: libddwaf_sys::DDWAF_OBJ_NULL,
-            #[allow(clippy::used_underscore_items)]
-            __bindgen_anon_1: libddwaf_sys::_ddwaf_object__bindgen_ty_1 { uintValue: 0},
-            nbEntries: 0,
-            parameterName: null_mut(),
-            parameterNameLength: 0,
-        } }
+        Self {
+            raw: libddwaf_sys::ddwaf_object {
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    u64_: libddwaf_sys::_ddwaf_object_unsigned {
+                        type_: libddwaf_sys::DDWAF_OBJ_NULL as u8,
+                        val: 0,
+                    },
+                },
+            }
+        }
     }
-});
+}
+);
 
 impl fmt::Debug for WafSigned {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -830,7 +1058,9 @@ impl From<u32> for WafUnsigned {
 
 impl<T: AsRef<[u8]>> From<T> for WafString {
     fn from(val: T) -> Self {
-        Self::new(val)
+        let slice = val.as_ref();
+        let slice = &slice[..slice.len().min(u32::MAX as usize)];
+        Self::new(slice).unwrap()
     }
 }
 impl fmt::Debug for WafString {
@@ -839,13 +1069,44 @@ impl fmt::Debug for WafString {
             f,
             "{}(\"{:?}\")",
             stringify!(WafString),
-            fmt_bin_str(self.bytes())
+            fmt_bin_str(self.as_bytes())
         )
     }
 }
 impl Drop for WafString {
     fn drop(&mut self) {
-        unsafe { self.raw.drop_string() }
+        // Only call drop_string for heap-allocated strings (DDWAF_OBJ_STRING)
+        // LITERAL_STRING (static) and SMALL_STRING (inline) don't need deallocation
+        if self.raw.obj_type() == libddwaf_sys::DDWAF_OBJ_STRING {
+            unsafe { self.raw.drop_string() }
+        }
+    }
+}
+impl Clone for WafString {
+    #[allow(clippy::cast_possible_truncation)]
+    fn clone(&self) -> Self {
+        if self.raw.obj_type() == libddwaf_sys::DDWAF_OBJ_STRING {
+            let len = self.len() as usize;
+            let layout = Layout::array::<std::os::raw::c_char>(len).unwrap();
+            let copied = unsafe { no_fail_alloc(layout).cast::<std::os::raw::c_char>() };
+            unsafe {
+                std::ptr::copy_nonoverlapping(self.as_bytes().as_ptr().cast(), copied, len);
+            }
+            return Self {
+                raw: libddwaf_sys::ddwaf_object {
+                    via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                        str_: libddwaf_sys::_ddwaf_object_string {
+                            type_: libddwaf_sys::DDWAF_OBJ_STRING as u8,
+                            size: len as u32,
+                            ptr: copied,
+                        },
+                    },
+                },
+            };
+        }
+
+        // other string types, just a plain copy
+        Self { raw: self.raw }
     }
 }
 
@@ -854,8 +1115,8 @@ impl AsRef<[WafObject]> for WafArray {
         if self.is_empty() {
             return &[];
         }
-        let array = unsafe { self.raw.__bindgen_anon_1.array.cast() };
-        unsafe { std::slice::from_raw_parts(array, self.len()) }
+        let array = unsafe { self.raw.via.array.ptr.cast() };
+        unsafe { std::slice::from_raw_parts(array, self.len() as usize) }
     }
 }
 impl AsMut<[WafObject]> for WafArray {
@@ -863,8 +1124,8 @@ impl AsMut<[WafObject]> for WafArray {
         if self.is_empty() {
             return &mut [];
         }
-        let array = unsafe { self.raw.__bindgen_anon_1.array.cast() };
-        unsafe { std::slice::from_raw_parts_mut(array, self.len()) }
+        let array = unsafe { self.raw.via.array.ptr.cast() };
+        unsafe { std::slice::from_raw_parts_mut(array, self.len() as usize) }
     }
 }
 impl fmt::Debug for WafArray {
@@ -887,10 +1148,67 @@ impl Drop for WafArray {
         unsafe { self.raw.drop_array() }
     }
 }
+impl Clone for WafArray {
+    #[allow(clippy::cast_possible_truncation)]
+    fn clone(&self) -> Self {
+        let size = self.len();
+
+        if size == 0 {
+            return Self::new(0);
+        }
+
+        let layout = Layout::array::<libddwaf_sys::ddwaf_object>(size as usize).unwrap();
+        let new_arr: *mut libddwaf_sys::ddwaf_object = unsafe { no_fail_alloc(layout).cast() };
+        unsafe { std::ptr::write_bytes(new_arr, 0, size as usize) };
+
+        // Clone each element
+        for i in 0..size {
+            let src_elem: &WafObject = &self[i as usize];
+            let cloned_elem = ManuallyDrop::new(src_elem.clone());
+            unsafe { new_arr.add(i as usize).write(cloned_elem.raw) };
+        }
+
+        Self {
+            raw: libddwaf_sys::ddwaf_object {
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    array: libddwaf_sys::_ddwaf_object_array {
+                        type_: libddwaf_sys::DDWAF_OBJ_ARRAY as u8,
+                        size,
+                        capacity: size,
+                        ptr: new_arr,
+                    },
+                },
+            },
+        }
+    }
+}
 impl<T: Into<WafObject>, const N: usize> From<[T; N]> for WafArray {
+    #[allow(clippy::cast_possible_truncation)]
     fn from(value: [T; N]) -> Self {
-        let mut array = Self::new(value.len() as u64);
+        let effective_length = N.min(u16::MAX as usize);
+        let mut array = Self::new(effective_length as u16);
         for (i, obj) in value.into_iter().enumerate() {
+            if i >= effective_length {
+                break;
+            }
+            array[i] = obj.into();
+        }
+        array
+    }
+}
+impl<T> From<&mut [T]> for WafArray
+where
+    T: Into<WafObject> + Default,
+{
+    #[allow(clippy::cast_possible_truncation)]
+    fn from(value: &mut [T]) -> Self {
+        let effective_length = value.len().min(u16::MAX as usize);
+        let mut array = Self::new(effective_length as u16);
+        for (i, obj) in value.iter_mut().enumerate() {
+            if i >= effective_length {
+                break;
+            }
+            let obj = std::mem::take(obj);
             array[i] = obj.into();
         }
         array
@@ -899,29 +1217,17 @@ impl<T: Into<WafObject>, const N: usize> From<[T; N]> for WafArray {
 impl Index<usize> for WafArray {
     type Output = WafObject;
     fn index(&self, index: usize) -> &Self::Output {
-        let obj: &libddwaf_sys::ddwaf_object = self.as_ref();
-        assert!(
-            // The object might be larger than [usize::MAX], but we ignore this for simplicity's sake.
-            index < usize::try_from(obj.nbEntries).unwrap_or(usize::MAX),
-            "index out of bounds ({} >= {})",
-            index,
-            obj.nbEntries
-        );
-        let array = unsafe { obj.__bindgen_anon_1.array };
+        let len = self.len() as usize;
+        assert!(index < len, "index out of bounds ({index} >= {len})");
+        let array = unsafe { self.raw.via.array.ptr };
         unsafe { &*(array.add(index) as *const _) }
     }
 }
 impl IndexMut<usize> for WafArray {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        let obj: &libddwaf_sys::ddwaf_object = self.as_ref();
-        assert!(
-            // The object might be larger than [usize::MAX], but we ignore this for simplicity's sake.
-            index < usize::try_from(obj.nbEntries).unwrap_or(usize::MAX),
-            "index out of bounds ({} >= {})",
-            index,
-            obj.nbEntries
-        );
-        let array = unsafe { obj.__bindgen_anon_1.array };
+        let len = self.len() as usize;
+        assert!(index < len, "index out of bounds ({index} >= {len})");
+        let array = unsafe { self.raw.via.array.ptr };
         unsafe { &mut *(array.add(index).cast()) }
     }
 }
@@ -931,8 +1237,8 @@ impl AsRef<[Keyed<WafObject>]> for WafMap {
         if self.is_empty() {
             return &[];
         }
-        let array = unsafe { self.raw.__bindgen_anon_1.array as *const _ };
-        unsafe { std::slice::from_raw_parts(array, self.len()) }
+        let ptr = unsafe { self.raw.via.map.ptr as *const _ };
+        unsafe { std::slice::from_raw_parts(ptr, self.len() as usize) }
     }
 }
 impl AsMut<[Keyed<WafObject>]> for WafMap {
@@ -940,8 +1246,8 @@ impl AsMut<[Keyed<WafObject>]> for WafMap {
         if self.is_empty() {
             return &mut [];
         }
-        let array = unsafe { self.raw.__bindgen_anon_1.array.cast() };
-        unsafe { std::slice::from_raw_parts_mut(array, self.len()) }
+        let ptr = unsafe { self.raw.via.map.ptr.cast() };
+        unsafe { std::slice::from_raw_parts_mut(ptr, self.len() as usize) }
     }
 }
 impl fmt::Debug for WafMap {
@@ -964,40 +1270,101 @@ impl Drop for WafMap {
         unsafe { self.raw.drop_map() }
     }
 }
+impl Clone for WafMap {
+    #[allow(clippy::cast_possible_truncation)]
+    fn clone(&self) -> Self {
+        let size = self.len();
+
+        if size == 0 {
+            return Self::new(0);
+        }
+
+        let layout = Layout::array::<libddwaf_sys::_ddwaf_object_kv>(size as usize).unwrap();
+        let new_ptr: *mut libddwaf_sys::_ddwaf_object_kv = unsafe { no_fail_alloc(layout).cast() };
+        unsafe { std::ptr::write_bytes(new_ptr, 0, size as usize) };
+
+        // Clone each key-value pair
+        for i in 0..size {
+            let src_entry: &Keyed<WafObject> = &self[i as usize];
+            let cloned_entry = ManuallyDrop::new(src_entry.clone());
+            unsafe { new_ptr.add(i as usize).write(cloned_entry.raw) };
+        }
+
+        Self {
+            raw: libddwaf_sys::ddwaf_object {
+                via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                    map: libddwaf_sys::_ddwaf_object_map {
+                        type_: libddwaf_sys::DDWAF_OBJ_MAP as u8,
+                        size,
+                        capacity: size,
+                        ptr: new_ptr,
+                    },
+                },
+            },
+        }
+    }
+}
 impl Index<usize> for WafMap {
     type Output = Keyed<WafObject>;
     fn index(&self, index: usize) -> &Self::Output {
-        let obj: &libddwaf_sys::ddwaf_object = self.as_ref();
-        assert!(
-            // The object might be larger than [usize::MAX], but we ignore this for simplicity's sake.
-            index < usize::try_from(obj.nbEntries).unwrap_or(usize::MAX),
-            "index out of bounds ({} >= {})",
-            index,
-            obj.nbEntries
-        );
-        let array = unsafe { obj.__bindgen_anon_1.array };
-        unsafe { &*array.add(index) }.as_keyed_object_ref()
+        let len = self.len() as usize;
+        assert!(index < len, "index out of bounds ({index} >= {len})");
+        let ptr = unsafe { self.raw.via.map.ptr };
+        unsafe { &*ptr.add(index).cast() }
     }
 }
 impl IndexMut<usize> for WafMap {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        let obj: &libddwaf_sys::ddwaf_object = self.as_ref();
-        assert!(
-            // The object might be larger than [usize::MAX], but we ignore this for simplicity's sake.
-            index < usize::try_from(obj.nbEntries).unwrap_or(usize::MAX),
-            "index out of bounds ({} >= {})",
-            index,
-            obj.nbEntries
-        );
-        let array = unsafe { obj.__bindgen_anon_1.array };
-        unsafe { (*array.add(index)).as_keyed_object_mut() }
+        let len = self.len() as usize;
+        assert!(index < len, "index out of bounds ({index} >= {len})");
+        let ptr = unsafe { self.raw.via.map.ptr };
+        unsafe { &mut *ptr.add(index).cast() }
     }
 }
 impl<K: AsRef<[u8]>, V: Into<WafObject>, const N: usize> From<[(K, V); N]> for WafMap {
+    #[allow(clippy::cast_possible_truncation)]
     fn from(vals: [(K, V); N]) -> Self {
-        let mut map = WafMap::new(N as u64);
+        let effective_length = N.min(u16::MAX as usize);
+        let mut map = WafMap::new(effective_length as u16);
         for (i, (k, v)) in vals.into_iter().enumerate() {
-            map[i] = Keyed::from((k.as_ref(), v));
+            if i >= effective_length {
+                break;
+            }
+            map[i] = Keyed::from((k.as_ref(), v.into()));
+        }
+        map
+    }
+}
+impl<V: Into<WafObject>, const N: usize> From<[(WafObject, V); N]> for WafMap {
+    #[allow(clippy::cast_possible_truncation)]
+    fn from(vals: [(WafObject, V); N]) -> Self {
+        let effective_length = N.min(u16::MAX as usize);
+        let mut map = WafMap::new(effective_length as u16);
+        for (i, (k, v)) in vals.into_iter().enumerate() {
+            if i >= effective_length {
+                break;
+            }
+            map[i] = (k, v.into()).into();
+        }
+        map
+    }
+}
+impl<K, V> From<&mut [(K, V)]> for WafMap
+where
+    K: Into<WafObject> + Default,
+    V: Into<WafObject> + Default,
+{
+    #[allow(clippy::cast_possible_truncation)]
+    fn from(value: &mut [(K, V)]) -> Self {
+        let effective_length = value.len().min(u16::MAX as usize);
+        let mut map = Self::new(effective_length as u16);
+        for (i, (k, v)) in value.iter_mut().enumerate() {
+            if i >= effective_length {
+                break;
+            }
+            let k = std::mem::take(k);
+            let v = std::mem::take(v);
+            map[i] = (k.into(), v.into()).into();
         }
         map
     }
@@ -1039,69 +1406,97 @@ impl From<()> for WafNull {
 /// An [`WafObject`] or [`TypedWafObject`] associated with a key.
 #[repr(transparent)]
 pub struct Keyed<T: AsRawMutObject> {
-    value: T,
+    raw: libddwaf_sys::_ddwaf_object_kv,
+    _marker: std::marker::PhantomData<T>,
 }
 impl<T: AsRawMutObject> Keyed<T> {
-    /// Creates a new [`Keyed<WafObject>`] wrapping the provided value, without setting the key..
-    pub(crate) fn new(value: T) -> Self {
-        Self { value }
+    /// Creates a new [`Keyed<WafObject>`] with the provided key and value.
+    pub fn new(key: impl Into<WafObject>, value: T) -> Self {
+        let key = key.into();
+        let val = *value.as_ref();
+        let ret = Self {
+            raw: libddwaf_sys::_ddwaf_object_kv { key: key.raw, val },
+            _marker: std::marker::PhantomData,
+        };
+        std::mem::forget(key);
+        std::mem::forget(value);
+        ret
     }
 
-    /// Obtains a reference to the wrapped value.
-    pub fn inner(&self) -> &T {
-        &self.value
+    // Obtains a reference to the map entry key.
+    #[must_use]
+    pub fn key(&self) -> &WafObject {
+        unsafe { self.raw.key.unchecked_as_ref() }
     }
 
-    /// Obtains the key associated with this [`Keyed<WafObject>`], as-is.
-    ///
-    /// # Panics
-    /// Panics if the underlying object's key is too long to be represented on this platform. This can only happen on
-    /// platforms where [`usize`] is 32-bit wide.
-    pub fn key(&self) -> &[u8] {
-        let obj = self.as_ref();
-        if obj.parameterNameLength == 0 {
-            return &[];
-        }
-        let len =
-            usize::try_from(obj.parameterNameLength).expect("key is too long for this platform");
-        unsafe { std::slice::from_raw_parts(obj.parameterName.cast(), len) }
+    /// Obtains a mutable reference to the map entry key.
+    #[must_use]
+    pub fn key_mut(&mut self) -> &mut WafObject {
+        unsafe { self.raw.key.unchecked_as_ref_mut() }
+    }
+
+    /// Obtains a reference to the map entry value.
+    #[must_use]
+    pub fn value(&self) -> &T {
+        unsafe { self.raw.val.unchecked_as_ref() }
+    }
+
+    /// Obtains a mutable reference to the map entry value.
+    #[must_use]
+    pub fn value_mut(&mut self) -> &mut T {
+        unsafe { self.raw.val.unchecked_as_ref_mut() }
     }
 
     /// Obtains the key associated with this [`Keyed<WafObject>`] as a string.
     ///
     /// # Errors
     /// Returns an error if the underlying key data is not a valid UTF-8 string, under the same conditions as
-    /// [`std::str::from_utf8`].
-    pub fn key_str(&self) -> Result<&str, std::str::Utf8Error> {
-        std::str::from_utf8(self.key())
+    /// [`std::str::from_utf8`] or if the key is not a [`WafString`].
+    #[allow(invalid_from_utf8)]
+    pub fn key_str(&self) -> Result<&str, Box<dyn std::error::Error>> {
+        std::str::from_utf8(self.key_bstr()?).map_err(std::convert::Into::into)
     }
 
-    /// Sets the key associated with this [`Keyed<WafObject>`].
-    pub fn set_key(&mut self, key: &[u8]) -> &mut Self {
-        let obj = unsafe { self.as_raw_mut() };
-        unsafe { obj.drop_key() };
-        if key.is_empty() {
-            obj.parameterName = null_mut();
-            obj.parameterNameLength = 0;
-            return self;
+    /// Obtains the key associated with this [`Keyed<WafObject>`] as a byte slice.
+    ///
+    /// # Errors
+    /// Returns an error if the underlying key data is not a [`WafString`].
+    pub fn key_bstr(&self) -> Result<&[u8], ObjectTypeError> {
+        let key = self.key();
+        match key.as_type::<WafString>() {
+            Some(s) => Ok(s.as_bytes()),
+            None => Err(ObjectTypeError {
+                expected: WafObjectType::String,
+                actual: key.get_type(),
+            }),
         }
+    }
 
-        let b: Box<[u8]> = key.into();
-        let ptr = Box::into_raw(b);
-        obj.parameterName = ptr.cast();
-        obj.parameterNameLength = key.len() as u64;
+    pub fn set_key(&mut self, key: impl Into<WafObject>) -> &mut Self {
+        let key = key.into();
+        self.raw.key = key.raw;
+        std::mem::forget(key);
         self
     }
 
+    /// Sets the key associated with this [`Keyed<WafObject>`].
+    /// If the key is longer than `u32::MAX` bytes, it will be truncated.
+    pub fn set_key_bstr(&mut self, key: &[u8]) -> &mut Self {
+        let key = WafString::from(key);
+        self.set_key(key)
+    }
+
     /// Sets the key associated with this [`Keyed<WafObject>`] to the provided string.
+    /// If the key is longer than `u32::MAX` bytes, it will be truncated.
     pub fn set_key_str(&mut self, key: &str) -> &mut Self {
-        self.set_key(key.as_bytes())
+        let key = WafString::from(key);
+        self.set_key(key)
     }
 }
 impl Keyed<WafObject> {
     #[must_use]
     pub fn as_type<T: TypedWafObject>(&self) -> Option<&Keyed<T>> {
-        if self.value.get_type() == T::TYPE {
+        if self.value().get_type() == T::TYPE {
             Some(unsafe { &*(std::ptr::from_ref(self).cast()) })
         } else {
             None
@@ -1109,7 +1504,7 @@ impl Keyed<WafObject> {
     }
 
     pub fn as_type_mut<T: TypedWafObject>(&mut self) -> Option<&mut Keyed<T>> {
-        if self.value.get_type() == T::TYPE {
+        if self.value().get_type() == T::TYPE {
             Some(unsafe { &mut *(std::ptr::from_mut(self).cast()) })
         } else {
             None
@@ -1120,93 +1515,134 @@ impl Keyed<WafObject> {
 // through [std::mem::take] or [std::mem::replace].
 impl Keyed<WafArray> {
     pub fn iter(&self) -> impl Iterator<Item = &WafObject> {
-        self.value.iter()
+        self.value().iter()
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut WafObject> {
-        self.value.iter_mut()
+        self.value_mut().iter_mut()
     }
 }
 // Note - We are not implementing DerefMut for Keyed as it'd allow leaking the key if it is used
 // through [std::mem::take] or [std::mem::replace].
 impl Keyed<WafMap> {
     pub fn iter(&self) -> impl Iterator<Item = &Keyed<WafObject>> {
-        self.value.iter()
+        self.value().iter()
     }
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Keyed<WafObject>> {
-        self.value.iter_mut()
+        self.value_mut().iter_mut()
     }
 }
-impl<T: AsRawMutObject> AsRawMutObject for Keyed<T> {
-    unsafe fn as_raw_mut(&mut self) -> &mut libddwaf_sys::ddwaf_object {
-        unsafe { self.value.as_raw_mut() }
-    }
-}
+// impl<T: AsRawMutObject> AsRawMutObject for Keyed<T> {
+//     unsafe fn as_raw_mut(&mut self) -> &mut libddwaf_sys::ddwaf_object {
+//         unsafe { self.value_mut().as_raw_mut() }
+//     }
+// }
 impl<T: AsRawMutObject> crate::private::Sealed for Keyed<T> {}
-impl<T: AsRawMutObject> AsRef<libddwaf_sys::ddwaf_object> for Keyed<T> {
-    fn as_ref(&self) -> &libddwaf_sys::ddwaf_object {
-        self.value.as_ref()
+impl<T: AsRawMutObject> AsRef<libddwaf_sys::_ddwaf_object_kv> for Keyed<T> {
+    fn as_ref(&self) -> &libddwaf_sys::_ddwaf_object_kv {
+        &self.raw
     }
 }
 impl<T: Default + AsRawMutObject> std::default::Default for Keyed<T> {
     fn default() -> Self {
-        Self {
-            value: T::default(),
-        }
+        let key = WafObject::default();
+        let mut value = T::default();
+        let ret = Self {
+            raw: libddwaf_sys::_ddwaf_object_kv {
+                key: key.raw,
+                val: *unsafe { value.as_raw_mut() },
+            },
+            _marker: std::marker::PhantomData,
+        };
+        std::mem::forget(key);
+        std::mem::forget(value);
+        ret
     }
 }
 impl<T: AsRawMutObject> Deref for Keyed<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        &self.value
+        self.value()
     }
 }
 impl<T: AsRawMutObject> std::ops::Drop for Keyed<T> {
     fn drop(&mut self) {
-        unsafe { self.as_raw_mut().drop_key() };
-        // self.value implicitly dropped
+        unsafe { self.raw.key.drop_object() };
+        unsafe { self.raw.val.drop_object() };
     }
 }
 impl<T: AsRawMutObject + fmt::Debug> fmt::Debug for Keyed<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "\"{:?}\"={:?}", fmt_bin_str(self.key()), self.value)
+        let k = self.key();
+        if k.get_type() == WafString::TYPE {
+            write!(
+                f,
+                "\"{:?}\"={:?}",
+                fmt_bin_str(unsafe { self.key().as_type_unchecked::<WafString>() }.as_bytes()),
+                self.value()
+            )
+        } else {
+            write!(f, "{:?}={:?}", k, self.value())
+        }
     }
 }
 impl<T, U: AsRawMutObject> From<(&str, T)> for Keyed<U>
 where
     T: Into<U>,
 {
-    fn from((key, value): (&str, T)) -> Self {
-        let unkeyed = value.into();
-        let mut keyed = Keyed::new(unkeyed);
-        keyed.set_key_str(key);
-        keyed
+    fn from(value: (&str, T)) -> Self {
+        (value.0.as_bytes(), value.1).into()
     }
 }
 impl<T, U: AsRawMutObject> From<(&[u8], T)> for Keyed<U>
 where
     T: Into<U>,
 {
-    fn from((key, value): (&[u8], T)) -> Self {
-        let unkeyed = value.into();
-        let mut keyed = Keyed::new(unkeyed);
-        keyed.set_key(key);
-        keyed
+    fn from(value: (&[u8], T)) -> Self {
+        let key: WafObject = value.0.into();
+        let value: U = value.1.into();
+        Keyed::new(key, value)
     }
 }
 impl<T: TypedWafObject> From<Keyed<T>> for Keyed<WafObject> {
     fn from(value: Keyed<T>) -> Self {
         let res = Self {
-            value: WafObject {
-                raw: *value.as_ref(),
-            },
+            raw: value.raw,
+            _marker: std::marker::PhantomData,
         };
         std::mem::forget(value);
         res
     }
 }
+impl From<(WafObject, WafObject)> for Keyed<WafObject> {
+    fn from(value: (WafObject, WafObject)) -> Self {
+        Keyed::new(value.0, value.1)
+    }
+}
+impl<T: TypedWafObject> From<(WafObject, T)> for Keyed<T> {
+    fn from(value: (WafObject, T)) -> Self {
+        Keyed::new(value.0, value.1)
+    }
+}
+impl<T: AsRawMutObject + Clone> Clone for Keyed<T> {
+    fn clone(&self) -> Self {
+        let cloned_key = self.key().clone();
+        let cloned_value = self.value().clone();
 
+        let ret = Self {
+            raw: libddwaf_sys::_ddwaf_object_kv {
+                key: cloned_key.raw,
+                val: *cloned_value.as_ref(),
+            },
+            _marker: std::marker::PhantomData,
+        };
+
+        std::mem::forget(cloned_key);
+        std::mem::forget(cloned_value);
+        ret
+    }
+}
 trait UncheckedAsRef: crate::private::Sealed {
     /// Converts a naked reference to a [`libddwaf_sys::ddwaf_object`] into a reference to one of the
     /// user-friendlier types.
@@ -1247,43 +1683,11 @@ impl UncheckedAsRef for libddwaf_sys::ddwaf_object {
 trait UncheckedAsWafObject: crate::private::Sealed {
     /// Converts a naked reference to a [`libddwaf_sys::ddwaf_object`] into a reference to an [`WafObject`].
     fn as_object_ref(&self) -> &WafObject;
-
-    /// Converts a naked reference to a [`libddwaf_sys::ddwaf_object`] into a reference to an opaque
-    /// [`Keyed<WafObject>`].
-    fn as_keyed_object_ref(&self) -> &Keyed<WafObject>;
-
-    /// Converts a naked mutable reference to a [`libddwaf_sys::ddwaf_object`] into a mutable reference to
-    /// an opaque [`Keyed<WafObject>`].
-    ///
-    /// # Safety
-    /// The caller must ensure that the destructor of [`Keyed<WafObject>`]
-    /// ([`libddwaf_sys::ddwaf_object::drop_key`] and [`libddwaf_sys::ddwaf_object::drop_object`]) can be called
-    /// on self.
-    unsafe fn as_keyed_object_mut(&mut self) -> &mut Keyed<WafObject>;
 }
 impl<T: UncheckedAsRef> UncheckedAsWafObject for T {
     /// Converts a naked reference to a [`libddwaf_sys::ddwaf_object`] into a reference to an [`WafObject`].
     fn as_object_ref(&self) -> &WafObject {
         unsafe { self.unchecked_as_ref::<WafObject>() }
-    }
-
-    /// Converts a naked reference to a [`libddwaf_sys::ddwaf_object`] into a reference to an opaque
-    /// [`Keyed<WafObject>`].
-    fn as_keyed_object_ref(&self) -> &Keyed<WafObject> {
-        // SAFETY: Keyed<WafObject> is compatible with all valid [libddwaf_sys::ddwaf_object] values,
-        // event if their key is not set.
-        unsafe { self.unchecked_as_ref::<Keyed<WafObject>>() }
-    }
-
-    /// Converts a naked mutable reference to a [`libddwaf_sys::ddwaf_object`] into a mutable reference to
-    /// an opaque [`Keyed<WafObject>`].
-    ///
-    /// # Safety
-    /// The caller must ensure that the destructor of [`Keyed<WafObject>`]
-    /// ([`libddwaf_sys::ddwaf_object::drop_key`] and [`libddwaf_sys::ddwaf_object::drop_object`]) can be called
-    /// on self.
-    unsafe fn as_keyed_object_mut(&mut self) -> &mut Keyed<WafObject> {
-        unsafe { self.unchecked_as_ref_mut::<Keyed<WafObject>>() }
     }
 }
 
@@ -1307,6 +1711,77 @@ fn fmt_bin_str(bytes: &[u8]) -> impl fmt::Debug + '_ {
     BinFormatter(bytes)
 }
 
+pub(crate) struct RustDdwafAllocator {
+    raw: libddwaf_sys::ddwaf_allocator,
+}
+impl RustDdwafAllocator {
+    fn new() -> Option<Self> {
+        let allocator = unsafe {
+            libddwaf_sys::ddwaf_user_allocator_init(
+                Some(Self::alloc_fn),
+                Some(Self::free_fn),
+                std::ptr::null_mut(),
+                Option::None,
+            )
+        };
+        if allocator.is_null() {
+            None
+        } else {
+            Some(Self { raw: allocator })
+        }
+    }
+    extern "C" fn alloc_fn(
+        _udata: *mut ::std::os::raw::c_void,
+        size: usize,
+        alignment: usize,
+    ) -> *mut ::std::os::raw::c_void {
+        let layout = Layout::from_size_align(size, alignment);
+        if let Ok(layout) = layout {
+            unsafe { std::alloc::alloc(layout).cast() }
+        } else {
+            debug_assert!(false, "Invalid layout");
+            std::ptr::null_mut()
+        }
+    }
+
+    extern "C" fn free_fn(
+        _udata: *mut ::std::os::raw::c_void,
+        ptr: *mut ::std::os::raw::c_void,
+        size: usize,
+        alignment: usize,
+    ) {
+        let layout = Layout::from_size_align(size, alignment);
+        match layout {
+            Ok(layout) => unsafe { std::alloc::dealloc(ptr.cast(), layout) },
+            Err(_) => {
+                debug_assert!(false, "Invalid layout");
+            }
+        }
+    }
+}
+
+impl Drop for RustDdwafAllocator {
+    fn drop(&mut self) {
+        unsafe { libddwaf_sys::ddwaf_allocator_destroy(self.raw) };
+    }
+}
+
+impl From<&RustDdwafAllocator> for libddwaf_sys::ddwaf_allocator {
+    fn from(allocator: &RustDdwafAllocator) -> Self {
+        allocator.raw
+    }
+}
+
+// RustDdwafAllocator is immutable
+unsafe impl Sync for RustDdwafAllocator {}
+unsafe impl Send for RustDdwafAllocator {}
+
+static DEFAULT_ALLOCATOR: OnceLock<RustDdwafAllocator> = OnceLock::new();
+
+pub(crate) fn get_default_allocator() -> &'static RustDdwafAllocator {
+    DEFAULT_ALLOCATOR.get_or_init(|| RustDdwafAllocator::new().unwrap())
+}
+
 /// Helper macro to create [`WafObject`]s.
 #[macro_export]
 macro_rules! waf_object {
@@ -1325,7 +1800,7 @@ macro_rules! waf_array {
     ($($e:expr),* $(,)?) => {
         {
             let size = [$($crate::__repl_expr_with_unit!($e)),*].len();
-            let mut res = $crate::object::WafArray::new(size as u64);
+            let mut res = $crate::object::WafArray::new(size as u16);
             let mut i = usize::MAX;
             $(
                 i = i.wrapping_add(1);
@@ -1343,13 +1818,13 @@ macro_rules! waf_map {
     ($(($k:literal, $v:expr)),* $(,)?) => {
         {
             let size = [$($crate::__repl_expr_with_unit!($v)),*].len();
-            let mut res = $crate::object::WafMap::new(size as u64);
+            let mut res = $crate::object::WafMap::new(u16::try_from(size).unwrap());
             let mut i = usize::MAX;
             $(
                 i = i.wrapping_add(1);
-                let k: &str = $k.into();
-                let obj = $crate::object::Keyed::<$crate::object::WafObject>::from((k, $v));
-                res[i] = obj.into();
+                let k = $crate::object::WafString::new_literal($k.as_bytes());
+                let val: $crate::object::WafObject = $v.into();
+                res[i] = $crate::object::Keyed::new(k, val);
             )*
             res
         }
@@ -1376,45 +1851,77 @@ mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)] // No operations are done on the values, they should be the same.
+    #[allow(clippy::cast_possible_truncation)]
     fn unsafe_changes_to_default_objects() {
         unsafe {
             let mut unsigned = WafUnsigned::default();
-            unsigned.as_raw_mut().__bindgen_anon_1.uintValue += 1;
+            unsigned.as_raw_mut().via.u64_.val += 1;
             assert_eq!(unsigned.value(), 1);
 
             let mut signed = WafSigned::default();
-            signed.as_raw_mut().__bindgen_anon_1.intValue -= 1;
+            signed.as_raw_mut().via.i64_.val -= 1;
             assert_eq!(signed.value(), -1);
 
             let mut float = WafFloat::default();
-            float.as_raw_mut().__bindgen_anon_1.f64_ += 1.0;
+            float.as_raw_mut().via.f64_.val += 1.0;
             assert_eq!(float.value(), 1.0);
 
             let mut boolean = WafBool::default();
-            boolean.as_raw_mut().__bindgen_anon_1.boolean = true;
+            boolean.as_raw_mut().via.b8.val = true;
             assert!(boolean.value());
 
-            let mut null = WafNull::default();
+            let null = WafNull::default();
             // nothing interesting to do for null; let's try manually setting
             // the parameter name
             let s = String::from_str("foobar").unwrap();
-            let b: Box<[u8]> = s.as_bytes().into();
-            let p = Box::<[u8]>::into_raw(b);
-            let null_mut = null.as_raw_mut();
-            null_mut.parameterName = p.cast();
-            null_mut.parameterNameLength = s.len() as u64;
-            drop(std::mem::take(null_mut.as_keyed_object_mut()));
+            let keyed_null = Keyed::new(WafString::from(s.as_str()), null);
+            std::mem::drop(keyed_null);
 
             let mut string = WafString::default();
             let str_mut = string.as_raw_mut();
-            let b: Box<[u8]> = s.as_bytes().into();
-            let p = Box::<[u8]>::into_raw(b);
+            let p: *mut u8 =
+                no_fail_alloc(Layout::array::<::std::os::raw::c_char>(s.len()).unwrap()).cast();
+            std::ptr::copy_nonoverlapping(s.as_ptr(), p.cast(), s.len());
             str_mut.drop_string();
-            str_mut.__bindgen_anon_1.stringValue = p as *const _;
-            str_mut.nbEntries = s.len() as u64;
+            str_mut.via.str_.ptr = p.cast();
+            str_mut.via.str_.size = s.len() as u32;
             assert_eq!(string.as_str().unwrap(), "foobar");
-            assert_eq!(string.len(), s.len());
+            assert_eq!(string.len(), s.len() as u32);
             assert!(!string.is_empty());
         }
+    }
+
+    #[test]
+    #[allow(clippy::cast_possible_truncation)]
+    fn string_representations_are_equivalent() {
+        const HELLO: &[u8] = b"hello";
+
+        let ss = WafString::new("hello").unwrap();
+        assert_eq!(ss.raw.obj_type(), libddwaf_sys::DDWAF_OBJ_SMALL_STRING);
+        assert!(ss.is_valid());
+        assert!(ss.raw.is_string());
+
+        let ls = WafString::new_literal(HELLO);
+        assert_eq!(ls.raw.obj_type(), libddwaf_sys::DDWAF_OBJ_LITERAL_STRING);
+        assert!(ls.is_valid());
+        assert!(ls.raw.is_string());
+        assert_eq!(ss, ls);
+
+        let ns = libddwaf_sys::ddwaf_object {
+            via: libddwaf_sys::_ddwaf_object__bindgen_ty_1 {
+                str_: libddwaf_sys::_ddwaf_object_string {
+                    type_: libddwaf_sys::DDWAF_OBJ_STRING as u8,
+                    size: HELLO.len() as u32,
+                    ptr: HELLO.as_ptr() as *mut _,
+                },
+            },
+        };
+        let ns = unsafe { ns.unchecked_as_ref::<WafString>() };
+        assert_eq!(ns.raw.obj_type(), libddwaf_sys::DDWAF_OBJ_STRING);
+        assert!(ns.is_valid());
+        assert!(ns.raw.is_string());
+        assert_eq!(ns.as_bytes(), HELLO);
+        assert_eq!(*ns, ss);
+        assert_eq!(*ns, ls);
     }
 }

--- a/crates/libddwaf/src/object/mod.rs
+++ b/crates/libddwaf/src/object/mod.rs
@@ -16,7 +16,7 @@ pub use iter::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum WafObjectType {
     /// An invalid value. This can be used as a placeholder to retain the key
-    /// associated with an object that was only aprtially encoded.
+    /// associated with an object that was only partially encoded.
     Invalid,
     /// A signed integer with 64-bit precision.
     Signed,
@@ -192,7 +192,7 @@ impl WafObject {
     /// Returns [`WafObjectType::Invalid`] if the underlying value's type is not set to a
     /// known, valid [`WafObjectType`] value.
     #[must_use]
-    pub fn get_type(&self) -> WafObjectType {
+    pub fn object_type(&self) -> WafObjectType {
         self.as_ref()
             .obj_type()
             .try_into()
@@ -202,7 +202,7 @@ impl WafObject {
     /// Returns a reference to this value as a `T` if its type corresponds.
     #[must_use]
     pub fn as_type<T: TypedWafObject>(&self) -> Option<&T> {
-        if self.get_type() == T::TYPE {
+        if self.object_type() == T::TYPE {
             Some(unsafe { self.as_type_unchecked::<T>() })
         } else {
             None
@@ -219,7 +219,7 @@ impl WafObject {
 
     /// Returns a mutable reference to this value as a `T` if its type corresponds.
     pub fn as_type_mut<T: TypedWafObject>(&mut self) -> Option<&mut T> {
-        if self.get_type() == T::TYPE {
+        if self.object_type() == T::TYPE {
             Some(unsafe { self.as_raw_mut().unchecked_as_ref_mut::<T>() })
         } else {
             None
@@ -230,7 +230,7 @@ impl WafObject {
     /// converted to one of the [`TypedWafObject`] implementations.
     #[must_use]
     pub fn is_valid(&self) -> bool {
-        self.get_type() != WafObjectType::Invalid
+        self.object_type() != WafObjectType::Invalid
     }
 
     /// Returns the value of this [`WafObject`] as a [`u64`] if its type is [`WafObjectType::Unsigned`].
@@ -243,7 +243,7 @@ impl WafObject {
     /// [`WafObjectType::Unsigned`] with a value that can be represented as an [`i64`]).
     #[must_use]
     pub fn to_i64(&self) -> Option<i64> {
-        match self.get_type() {
+        match self.object_type() {
             WafObjectType::Unsigned => {
                 let obj: &WafUnsigned = unsafe { self.as_type_unchecked() };
                 obj.value().try_into().ok()
@@ -287,7 +287,7 @@ impl AsRawMutObject for WafObject {
 }
 impl fmt::Debug for WafObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.get_type() {
+        match self.object_type() {
             WafObjectType::Invalid => write!(f, "WafInvalid"),
             WafObjectType::Unsigned => {
                 let obj: &WafUnsigned = self.as_type().unwrap();
@@ -331,7 +331,7 @@ impl Drop for WafObject {
 }
 impl Clone for WafObject {
     fn clone(&self) -> Self {
-        match self.get_type() {
+        match self.object_type() {
             WafObjectType::Invalid => {
                 let obj: &WafInvalid = unsafe { self.as_type_unchecked() };
                 (*obj).into()
@@ -585,10 +585,10 @@ macro_rules! typed_object {
         impl TryFrom<WafObject> for $name {
             type Error = ObjectTypeError;
             fn try_from(obj: WafObject) -> Result<Self, Self::Error> {
-                if obj.get_type() != Self::TYPE {
+                if obj.object_type() != Self::TYPE {
                     return Err(ObjectTypeError {
                         expected: $type,
-                        actual: obj.get_type(),
+                        actual: obj.object_type(),
                     });
                 }
                 let res = Self { raw: obj.raw };
@@ -1204,7 +1204,6 @@ impl Clone for WafArray {
 
         let layout = Layout::array::<libddwaf_sys::ddwaf_object>(size as usize).unwrap();
         let new_arr: *mut libddwaf_sys::ddwaf_object = unsafe { no_fail_alloc(layout).cast() };
-        unsafe { std::ptr::write_bytes(new_arr, 0, size as usize) };
 
         // Clone each element
         for i in 0..size {
@@ -1513,35 +1512,15 @@ impl<T: AsRawMutObject> Keyed<T> {
             Some(s) => Ok(s.as_bytes()),
             None => Err(ObjectTypeError {
                 expected: WafObjectType::String,
-                actual: key.get_type(),
+                actual: key.object_type(),
             }),
         }
-    }
-
-    pub fn set_key(&mut self, key: impl Into<WafObject>) -> &mut Self {
-        let key = key.into();
-        self.raw.key = key.raw;
-        std::mem::forget(key);
-        self
-    }
-
-    /// Sets the key associated with this [`Keyed<WafObject>`].
-    /// If the key is longer than `u32::MAX` bytes, it will be truncated.
-    pub fn set_key_bytes(&mut self, key: &[u8]) -> &mut Self {
-        let key = WafString::from(key);
-        self.set_key(key)
-    }
-
-    /// Sets the key associated with this [`Keyed<WafObject>`] to the provided string.
-    /// If the key is longer than `u32::MAX` bytes, it will be truncated.
-    pub fn set_key_str(&mut self, key: impl Into<WafString>) -> &mut Self {
-        self.set_key(key.into())
     }
 }
 impl Keyed<WafObject> {
     #[must_use]
     pub fn as_type<T: TypedWafObject>(&self) -> Option<&Keyed<T>> {
-        if self.value().get_type() == T::TYPE {
+        if self.value().object_type() == T::TYPE {
             Some(unsafe { &*(std::ptr::from_ref(self).cast()) })
         } else {
             None
@@ -1549,7 +1528,7 @@ impl Keyed<WafObject> {
     }
 
     pub fn as_type_mut<T: TypedWafObject>(&mut self) -> Option<&mut Keyed<T>> {
-        if self.value().get_type() == T::TYPE {
+        if self.value().object_type() == T::TYPE {
             Some(unsafe { &mut *(std::ptr::from_mut(self).cast()) })
         } else {
             None
@@ -1620,7 +1599,7 @@ impl<T: AsRawMutObject> std::ops::Drop for Keyed<T> {
 impl<T: AsRawMutObject + fmt::Debug> fmt::Debug for Keyed<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let k = self.key();
-        if k.get_type() == WafString::TYPE {
+        if k.object_type() == WafString::TYPE {
             write!(
                 f,
                 "\"{:?}\"={:?}",

--- a/crates/libddwaf/src/object/mod.rs
+++ b/crates/libddwaf/src/object/mod.rs
@@ -167,23 +167,24 @@ impl WafObject {
     /// # Returns
     /// Returns [`None`] if parsing the JSON string into a [`WafObject`] was not
     /// possible, or if the input JSON string is larger than [`u32::MAX`] bytes.
-    pub fn from_json(json: impl AsRef<[u8]>) -> Option<WafOwned<Self>> {
-        let mut obj = WafOwned::<Self>::default();
+    pub fn from_json(json: impl AsRef<[u8]>) -> Option<WafOwnedOutputAllocator<Self>> {
+        let mut output = WafOwnedOutputAllocator::<Self>::default();
         let data = json.as_ref();
         let Ok(len) = u32::try_from(data.len()) else {
             return None;
         };
         if !unsafe {
+            let alloc = WafOwnedOutputAllocator::<Self>::get_allocator();
             libddwaf_sys::ddwaf_object_from_json(
-                obj.as_raw_mut(),
+                output.as_raw_mut(),
                 data.as_ptr().cast(),
                 len,
-                get_default_allocator().into(),
+                alloc,
             )
         } {
             return None;
         }
-        Some(obj)
+        Some(output)
     }
 
     /// Returns the [`WafObjectType`] of the underlying value.
@@ -432,47 +433,75 @@ impl<T: AsRef<libddwaf_sys::ddwaf_object>> cmp::PartialEq<T> for WafObject {
 }
 impl crate::private::Sealed for WafObject {}
 
+/// Trait to encode which allocator should be used for deallocation in the type system.
+pub trait AllocatorType: 'static {
+    /// Get the allocator to use for deallocation.
+    fn get_allocator() -> libddwaf_sys::ddwaf_allocator;
+}
+
+/// Allocator type that uses the system default allocator.
+pub struct SystemDefaultAllocator;
+impl AllocatorType for SystemDefaultAllocator {
+    fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
+        unsafe { libddwaf_sys::ddwaf_get_default_allocator() }
+    }
+}
+
+/// Allocator type that uses the Rust-registered allocator.
+pub struct RustAllocator;
+impl AllocatorType for RustAllocator {
+    fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
+        get_default_allocator().into()
+    }
+}
+
 /// A WAF-owned [`WafObject`] or [`TypedWafObject`] value.
 ///
 /// This has different [`Drop`] behavior than a rust-owned [`WafObject`] value.
-pub struct WafOwned<T: AsRawMutObject> {
+/// The allocator used for deallocation is encoded in the type parameter `A`.
+#[repr(transparent)]
+pub struct WafOwned<T: AsRawMutObject, A: AllocatorType = RustAllocator> {
     inner: std::mem::ManuallyDrop<T>,
+    _phantom: std::marker::PhantomData<A>,
 }
-impl<T: AsRawMutObject + fmt::Debug> fmt::Debug for WafOwned<T> {
+impl<T: AsRawMutObject, A: AllocatorType> WafOwned<T, A> {
+    pub(crate) fn get_allocator() -> libddwaf_sys::ddwaf_allocator {
+        A::get_allocator()
+    }
+}
+
+impl<T: AsRawMutObject + fmt::Debug, A: AllocatorType> fmt::Debug for WafOwned<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.inner.deref().fmt(f)
     }
 }
-impl<T: AsRawMutObject + Default> Default for WafOwned<T> {
+impl<T: AsRawMutObject + Default, A: AllocatorType> Default for WafOwned<T, A> {
     fn default() -> Self {
         Self {
             inner: std::mem::ManuallyDrop::new(Default::default()),
+            _phantom: std::marker::PhantomData,
         }
     }
 }
-impl<T: AsRawMutObject> Deref for WafOwned<T> {
+impl<T: AsRawMutObject, A: AllocatorType> Deref for WafOwned<T, A> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
-impl<T: AsRawMutObject> DerefMut for WafOwned<T> {
+impl<T: AsRawMutObject, A: AllocatorType> DerefMut for WafOwned<T, A> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
-impl<T: AsRawMutObject> Drop for WafOwned<T> {
+impl<T: AsRawMutObject, A: AllocatorType> Drop for WafOwned<T, A> {
     fn drop(&mut self) {
         unsafe {
-            libddwaf_sys::ddwaf_object_destroy(
-                self.inner.as_raw_mut(),
-                // we use this allocator in `Handle::new_context`
-                get_default_allocator().into(),
-            );
+            libddwaf_sys::ddwaf_object_destroy(self.inner.as_raw_mut(), A::get_allocator());
         }
     }
 }
-impl<T: AsRawMutObject> PartialEq<T> for WafOwned<T>
+impl<T: AsRawMutObject, A: AllocatorType> PartialEq<T> for WafOwned<T, A>
 where
     T: PartialEq<T>,
 {
@@ -480,6 +509,12 @@ where
         *self.inner == *other
     }
 }
+
+/// Type alias for WAF-owned objects using the system default allocator.
+pub type WafOwnedDefaultAllocator<T> = WafOwned<T, SystemDefaultAllocator>;
+
+/// Type alias for WAF-owned objects using the Rust-registered allocator (for outputs).
+pub type WafOwnedOutputAllocator<T> = WafOwned<T, RustAllocator>;
 
 /// Allocates memory for the given [`Layout`], calling [`std::alloc::handle_alloc_error`] if the
 /// allocation failed.

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -134,7 +134,7 @@ impl serde::Serialize for WafObject {
     where
         S: serde::Serializer,
     {
-        match self.get_type() {
+        match self.object_type() {
             WafObjectType::Unsigned => {
                 unsafe { self.as_type_unchecked::<WafUnsigned>() }.serialize(serializer)
             }

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -1,8 +1,6 @@
 //! Implementations of [`serde::Deserialize`] for [`object::WafObject`](crate::object::WafObject) and
 //! [`object::WafMap`](crate::object::WafMap).
 
-use std::borrow::Cow;
-
 use serde::{
     Deserializer,
     de::Error,
@@ -10,7 +8,7 @@ use serde::{
 };
 
 use crate::object::{
-    WafArray, WafBool, WafFloat, WafMap, WafObject, WafObjectType, WafSigned, WafString,
+    Keyed, WafArray, WafBool, WafFloat, WafMap, WafObject, WafObjectType, WafSigned, WafString,
     WafUnsigned,
 };
 
@@ -84,7 +82,7 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     where
         E: Error,
     {
-        Ok(WafObject::from(WafString::new(v)))
+        Ok(WafObject::from(WafString::from(v)))
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
@@ -106,15 +104,14 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
     where
         A: serde::de::MapAccess<'de>,
     {
-        let mut vec: Vec<(Cow<'de, str>, WafObject)> =
+        let mut vec: Vec<(WafObject, WafObject)> =
             map.size_hint().map(Vec::with_capacity).unwrap_or_default();
-        while let Some((key, value)) = map.next_entry::<Cow<'de, str>, WafObject>()? {
+        while let Some((key, value)) = map.next_entry::<WafObject, WafObject>()? {
             vec.push((key, value));
         }
-        let mut res = WafMap::new(vec.len().try_into().unwrap());
+        let mut res = WafMap::new(vec.len().try_into().map_err(A::Error::custom)?);
         for (i, (k, v)) in vec.into_iter().enumerate() {
-            let key_str: &str = &k;
-            res[i] = (key_str, v).into();
+            res[i] = Keyed::new(k, v);
         }
         Ok(res.into())
     }
@@ -193,7 +190,7 @@ impl serde::Serialize for WafString {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&String::from_utf8_lossy(self.bytes()))
+        serializer.serialize_str(&String::from_utf8_lossy(self.as_bytes()))
     }
 }
 
@@ -202,7 +199,7 @@ impl serde::Serialize for WafArray {
     where
         S: serde::Serializer,
     {
-        let mut seq_serializer = serializer.serialize_seq(Some(self.len()))?;
+        let mut seq_serializer = serializer.serialize_seq(Some(self.len() as usize))?;
         for value in self.iter() {
             seq_serializer.serialize_element(value)?;
         }
@@ -215,10 +212,11 @@ impl serde::Serialize for WafMap {
     where
         S: serde::Serializer,
     {
-        let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
+        let mut map_serializer = serializer.serialize_map(Some(self.len() as usize))?;
         for keyed_val in self.iter() {
-            map_serializer
-                .serialize_entry(&String::from_utf8_lossy(keyed_val.key()), keyed_val.inner())?;
+            // Key is serialized as WafObject; formats requiring string keys (e.g. JSON)
+            // will error if the key is not a WafString
+            map_serializer.serialize_entry(keyed_val.key(), keyed_val.value())?;
         }
         map_serializer.end()
     }

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -62,6 +62,13 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
         Ok(WafObject::from(v))
     }
 
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(WafObject::from(v))
+    }
+
     fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
     where
         E: Error,

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -7,9 +7,9 @@
 use std::cell::Cell;
 
 use serde::{
-    Deserializer,
     de::Error,
     ser::{SerializeMap, SerializeSeq},
+    Deserializer,
 };
 
 use crate::object::{

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -1,5 +1,10 @@
 //! Implementations of [`serde::Deserialize`] for [`object::WafObject`](crate::object::WafObject) and
 //! [`object::WafMap`](crate::object::WafMap).
+//!
+//! This module also provides [`Limits`] for applying constraints during deserialization,
+//! similar to the PHP extension's `dd_mpack_limits` structure.
+
+use std::cell::Cell;
 
 use serde::{
     Deserializer,
@@ -8,8 +13,8 @@ use serde::{
 };
 
 use crate::object::{
-    Keyed, WafArray, WafBool, WafFloat, WafMap, WafObject, WafObjectType, WafSigned, WafString,
-    WafUnsigned,
+    Keyed, WafArray, WafBool, WafFloat, WafMap, WafNull, WafObject, WafObjectType, WafSigned,
+    WafString, WafUnsigned,
 };
 
 impl<'de> serde::Deserialize<'de> for WafObject {
@@ -219,5 +224,385 @@ impl serde::Serialize for WafMap {
             map_serializer.serialize_entry(keyed_val.key(), keyed_val.value())?;
         }
         map_serializer.end()
+    }
+}
+
+/// Default maximum string length (4096 bytes).
+pub const DEFAULT_MAX_STRING_LENGTH: u32 = 4096;
+
+/// Default maximum depth (21 levels).
+pub const DEFAULT_MAX_DEPTH: usize = 21;
+
+/// Default maximum elements (2048 elements).
+pub const DEFAULT_MAX_ELEMENTS: usize = 2048;
+
+/// Limits applied during deserialization to prevent excessive resource usage.
+///
+/// This is modeled after the PHP extension's `dd_mpack_limits` structure:
+/// - `max_string_length`: Strings longer than this are truncated
+/// - `max_depth`: Maximum nesting depth; deeper structures become null
+/// - `max_elements`: Maximum total elements; excess elements are skipped
+///
+/// # Example
+/// ```
+/// use libddwaf::serde::Limits;
+///
+/// let limits = Limits::default();
+/// assert_eq!(limits.max_string_length, 4096);
+/// assert_eq!(limits.max_depth, 21);
+/// assert_eq!(limits.max_elements, 2048);
+///
+/// // Create custom limits
+/// let custom = Limits {
+///     max_string_length: 1024,
+///     max_depth: 10,
+///     max_elements: 100,
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct Limits {
+    pub max_string_length: u32,
+    pub max_depth: usize,
+    pub max_elements: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_string_length: DEFAULT_MAX_STRING_LENGTH,
+            max_depth: DEFAULT_MAX_DEPTH,
+            max_elements: DEFAULT_MAX_ELEMENTS,
+        }
+    }
+}
+
+/// The result of deserializing with limits.
+#[derive(Debug)]
+pub struct LimitedResult<T> {
+    /// The deserialized value.
+    pub value: T,
+    /// Whether any limits were reached during deserialization.
+    pub truncated: bool,
+}
+
+/// Deserialize a [`WafObject`] from a deserializer with the specified limits.
+///
+/// Returns a [`LimitedResult`] containing the deserialized value and whether
+/// truncation occurred.
+///
+/// # Example
+/// ```
+/// use libddwaf::serde::{Limits, deserialize_with_limits};
+/// use libddwaf::object::WafObject;
+///
+/// let json = r#"{"key": "value"}"#;
+/// let limits = Limits {
+///     max_string_length: 3,
+///     max_depth: 10,
+///     max_elements: 100,
+/// };
+/// let mut deserializer = serde_json::Deserializer::from_str(json);
+/// let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+///
+/// assert!(result.truncated); // "value" was truncated to "val"
+/// ```
+/// # Errors
+/// Returns an error if the deserializer returns an error.
+pub fn deserialize_with_limits<'de, D>(
+    deserializer: D,
+    limits: &Limits,
+) -> Result<LimitedResult<WafObject>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let state = LimitedState::new(limits);
+    let visitor = LimitedVisitor { state: &state };
+    let value = deserializer.deserialize_any(visitor)?;
+    Ok(LimitedResult {
+        value,
+        truncated: state.truncated.get(),
+    })
+}
+
+struct LimitedState<'a> {
+    limits: &'a Limits,
+    depth_remaining: Cell<usize>,
+    elements_remaining: Cell<usize>,
+    truncated: Cell<bool>,
+}
+
+impl<'a> LimitedState<'a> {
+    fn new(limits: &'a Limits) -> Self {
+        Self {
+            limits,
+            depth_remaining: Cell::new(limits.max_depth),
+            elements_remaining: Cell::new(limits.max_elements),
+            truncated: Cell::new(false),
+        }
+    }
+
+    /// Consumes one element from the remaining count.
+    /// Returns true if the element can be processed, false if limit reached.
+    fn consume_element(&self) -> bool {
+        let remaining = self.elements_remaining.get();
+        if remaining == 0 {
+            self.truncated.set(true);
+            false
+        } else {
+            self.elements_remaining.set(remaining - 1);
+            true
+        }
+    }
+
+    fn can_descend(&self) -> bool {
+        self.depth_remaining.get() > 0
+    }
+
+    fn enter_depth(&self) {
+        let depth = self.depth_remaining.get();
+        if depth > 0 {
+            self.depth_remaining.set(depth - 1);
+        }
+    }
+
+    fn exit_depth(&self) {
+        self.depth_remaining.set(self.depth_remaining.get() + 1);
+    }
+
+    fn truncate_string<'b>(&self, s: &'b str) -> &'b str {
+        if s.len() > self.limits.max_string_length as usize {
+            self.truncated.set(true);
+            // Find a valid UTF-8 boundary
+            let mut end = self.limits.max_string_length as usize;
+            while end > 0 && !s.is_char_boundary(end) {
+                end -= 1;
+            }
+            &s[..end]
+        } else {
+            s
+        }
+    }
+
+    fn truncate_bytes<'b>(&self, b: &'b [u8]) -> &'b [u8] {
+        if b.len() > self.limits.max_string_length as usize {
+            self.truncated.set(true);
+            &b[..self.limits.max_string_length as usize]
+        } else {
+            b
+        }
+    }
+}
+
+/// A visitor that applies limits during deserialization.
+struct LimitedVisitor<'a> {
+    state: &'a LimitedState<'a>,
+}
+
+impl<'de, 'a> serde::de::Visitor<'de> for LimitedVisitor<'a> {
+    type Value = WafObject;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str(
+            "a valid WafObject (unsigned, signed, string, array, map, bool, float, or null)",
+        )
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        Ok(WafObject::from(v))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        Ok(WafObject::from(v))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        Ok(WafObject::from(v))
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        Ok(WafObject::from(v))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        Ok(WafObject::from(()))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        let truncated = self.state.truncate_string(v);
+        Ok(WafObject::from(truncated))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        if !self.state.consume_element() {
+            return Ok(WafNull::new().into());
+        }
+        let truncated = self.state.truncate_bytes(v);
+        Ok(WafObject::from(WafString::from(truncated)))
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        if !self.state.can_descend() {
+            self.state.truncated.set(true);
+            // Drain the sequence
+            while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+            return Ok(WafNull::new().into());
+        }
+
+        // Consume element for the array itself
+        if !self.state.consume_element() {
+            // Drain the sequence
+            while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+            return Ok(WafNull::new().into());
+        }
+
+        self.state.enter_depth();
+
+        let mut vec = seq.size_hint().map(Vec::with_capacity).unwrap_or_default();
+        while self.state.elements_remaining.get() > 0 {
+            match seq.next_element_seed(LimitedSeed { state: self.state })? {
+                Some(value) => vec.push(value),
+                None => break,
+            }
+        }
+
+        // If there are remaining elements, drain them and mark as truncated
+        if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+            self.state.truncated.set(true);
+            while seq.next_element::<serde::de::IgnoredAny>()?.is_some() {}
+        }
+
+        self.state.exit_depth();
+
+        let len = vec.len().min(u16::MAX as usize);
+        let mut res = WafArray::new(len as u16);
+        for (i, v) in vec.into_iter().take(len).enumerate() {
+            res[i] = v;
+        }
+        Ok(res.into())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        // Check if we can descend
+        if !self.state.can_descend() {
+            self.state.truncated.set(true);
+            // Drain the map
+            while map
+                .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                .is_some()
+            {}
+            return Ok(WafNull::new().into());
+        }
+
+        // Consume element for the map itself
+        if !self.state.consume_element() {
+            // Drain the map
+            while map
+                .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                .is_some()
+            {}
+            return Ok(WafNull::new().into());
+        }
+
+        self.state.enter_depth();
+
+        let mut vec: Vec<Keyed<WafObject>> =
+            map.size_hint().map(Vec::with_capacity).unwrap_or_default();
+
+        while self.state.elements_remaining.get() > 0 {
+            match map.next_entry_seed(LimitedSeed { state: self.state }, LimitedSeed {
+                state: self.state,
+            })? {
+                Some(pair @ (_, _)) => vec.push(pair.into()),
+                None => break,
+            }
+        }
+
+        // If there are remaining entries, drain them and mark as truncated
+        if map
+            .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+            .is_some()
+        {
+            self.state.truncated.set(true);
+            while map
+                .next_entry::<serde::de::IgnoredAny, serde::de::IgnoredAny>()?
+                .is_some()
+            {}
+        }
+
+        self.state.exit_depth();
+
+        let len = vec.len().min(u16::MAX as usize);
+        let mut res = WafMap::new(len as u16);
+        for (i, keyed) in vec.into_iter().take(len).enumerate() {
+            res[i] = keyed;
+        }
+        Ok(res.into())
+    }
+}
+
+/// A `DeserializeSeed` that uses the limited visitor.
+struct LimitedSeed<'a> {
+    state: &'a LimitedState<'a>,
+}
+
+impl<'de, 'a> serde::de::DeserializeSeed<'de> for LimitedSeed<'a>
+where
+    'de: 'a,
+{
+    type Value = WafObject;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let visitor = LimitedVisitor { state: self.state };
+        deserializer.deserialize_any(visitor)
     }
 }

--- a/crates/libddwaf/src/serde.rs
+++ b/crates/libddwaf/src/serde.rs
@@ -405,7 +405,7 @@ struct LimitedVisitor<'a> {
     state: &'a LimitedState<'a>,
 }
 
-impl<'de, 'a> serde::de::Visitor<'de> for LimitedVisitor<'a> {
+impl<'de> serde::de::Visitor<'de> for LimitedVisitor<'_> {
     type Value = WafObject;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -563,9 +563,10 @@ impl<'de, 'a> serde::de::Visitor<'de> for LimitedVisitor<'a> {
             map.size_hint().map(Vec::with_capacity).unwrap_or_default();
 
         while self.state.elements_remaining.get() > 0 {
-            match map.next_entry_seed(LimitedSeed { state: self.state }, LimitedSeed {
-                state: self.state,
-            })? {
+            match map.next_entry_seed(
+                LimitedSeed { state: self.state },
+                LimitedSeed { state: self.state },
+            )? {
                 Some(pair @ (_, _)) => vec.push(pair.into()),
                 None => break,
             }

--- a/crates/libddwaf/tests/builder.rs
+++ b/crates/libddwaf/tests/builder.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use libddwaf::{
     Builder, Config,
     object::{WafMap, WafOwned},

--- a/crates/libddwaf/tests/builder.rs
+++ b/crates/libddwaf/tests/builder.rs
@@ -6,7 +6,7 @@ use libddwaf::{
 
 #[test]
 pub fn blank_config() {
-    let mut builder = Builder::new(&Config::default()).expect("builder should be created");
+    let mut builder = Builder::new(Some(&Config::default())).expect("builder should be created");
     // Not adding any rules, so we can't get a handle...
     assert!(builder.build().is_none());
 }
@@ -19,13 +19,13 @@ pub fn blank_config() {
     )
 )]
 pub fn empty_path() {
-    let mut builder = Builder::new(&Config::default()).expect("builder should be created");
+    let mut builder = Builder::new(Some(&Config::default())).expect("builder should be created");
     assert!(!builder.add_or_update_config("", &waf_map! {}, None)); // Panics when debug_assertions is enabled
 }
 
 #[test]
 pub fn add_update_remove_config() {
-    let mut builder = Builder::new(&Config::default()).expect("builder should be created");
+    let mut builder = Builder::new(None).expect("builder should be created");
 
     let rules_1 = waf_map! {
         ("version", "2.1"),
@@ -84,7 +84,9 @@ pub fn add_update_remove_config() {
     assert!(builder.add_or_update_config("test", &rules_1, Some(&mut diagnostics)));
     assert!(diagnostics.is_valid());
     assert_eq!(
-        diagnostics.get(b"ruleset_version").and_then(|o| o.to_str()),
+        diagnostics
+            .get_bstr(b"ruleset_version")
+            .and_then(|o| o.to_str()),
         Some("1"),
     );
     assert_eq!(builder.config_paths_count(None), 1);
@@ -95,7 +97,9 @@ pub fn add_update_remove_config() {
     assert!(builder.add_or_update_config("test", &rules_2, Some(&mut diagnostics)));
     assert!(diagnostics.is_valid());
     assert_eq!(
-        diagnostics.get(b"ruleset_version").and_then(|o| o.to_str()),
+        diagnostics
+            .get_bstr(b"ruleset_version")
+            .and_then(|o| o.to_str()),
         Some("2"),
     );
     assert_eq!(builder.config_paths_count(None), 1);

--- a/crates/libddwaf/tests/builder.rs
+++ b/crates/libddwaf/tests/builder.rs
@@ -1,9 +1,8 @@
 #![cfg(not(miri))]
 
 use libddwaf::{
-    Builder, Config,
     object::{WafMap, WafOwnedDefaultAllocator},
-    waf_array, waf_map,
+    waf_array, waf_map, Builder, Config,
 };
 
 #[test]

--- a/crates/libddwaf/tests/builder.rs
+++ b/crates/libddwaf/tests/builder.rs
@@ -2,7 +2,7 @@
 
 use libddwaf::{
     Builder, Config,
-    object::{WafMap, WafOwned},
+    object::{WafMap, WafOwnedDefaultAllocator},
     waf_array, waf_map,
 };
 
@@ -82,7 +82,7 @@ pub fn add_update_remove_config() {
 
     assert_eq!(builder.config_paths_count(None), 0);
 
-    let mut diagnostics = WafOwned::<WafMap>::default();
+    let mut diagnostics = WafOwnedDefaultAllocator::<WafMap>::default();
     assert!(builder.add_or_update_config("test", &rules_1, Some(&mut diagnostics)));
     assert!(diagnostics.is_valid());
     assert_eq!(

--- a/crates/libddwaf/tests/clone.rs
+++ b/crates/libddwaf/tests/clone.rs
@@ -1,0 +1,275 @@
+use libddwaf::{object::*, waf_array, waf_map};
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn clone_simple_types() {
+    let orig = WafSigned::new(42);
+    let copy = orig;
+    assert_eq!(orig.value(), copy.value());
+    assert_eq!(orig.value(), 42);
+
+    let orig = WafUnsigned::new(123);
+    let cloned = orig;
+    assert_eq!(orig, cloned);
+    assert_eq!(cloned.value(), 123);
+
+    let invalid = WafInvalid::default();
+    let invalid_clone = invalid;
+    assert!(invalid == invalid_clone);
+
+    let signed = WafSigned::new(-42);
+    let signed_clone = signed;
+    assert_eq!(signed, signed_clone);
+
+    let unsigned = WafUnsigned::new(42);
+    let unsigned_clone = unsigned;
+    assert_eq!(unsigned, unsigned_clone);
+
+    let boolean = WafBool::new(true);
+    let boolean_clone = boolean;
+    assert_eq!(boolean, boolean_clone);
+
+    let float = WafFloat::new(3.28);
+    let float_clone = float;
+    assert_eq!(float, float_clone);
+
+    let null = WafNull::new();
+    let null_clone = null;
+    assert_eq!(null, null_clone);
+}
+
+#[test]
+fn clone_string_variants() {
+    // SMALL_STRING (< 14 bytes)
+    let small = WafString::new("hello").unwrap();
+    let cloned = small.clone();
+    assert_eq!(small.as_bytes(), cloned.as_bytes());
+    drop(small);
+    assert_eq!(cloned.as_bytes(), b"hello");
+
+    // STRING (heap-allocated, > 14 bytes)
+    let large = WafString::new("a".repeat(100)).unwrap();
+    let cloned = large.clone();
+    assert_eq!(large.as_bytes(), cloned.as_bytes());
+    drop(large);
+    assert_eq!(cloned.len(), 100);
+
+    // LITERAL_STRING
+    const STATIC_BYTES: &[u8] = b"static";
+    let literal = WafString::new_literal(STATIC_BYTES);
+    let cloned = literal.clone();
+    assert_eq!(literal.as_bytes(), cloned.as_bytes());
+    drop(literal);
+    assert_eq!(cloned.as_bytes(), b"static");
+
+    // Empty strings
+    let empty = WafString::new("").unwrap();
+    let cloned = empty.clone();
+    assert_eq!(cloned.len(), 0);
+    assert!(cloned.is_empty());
+}
+
+#[test]
+fn clone_empty_containers() {
+    let empty_arr = WafArray::new(0);
+    let cloned_arr = empty_arr.clone();
+    assert_eq!(cloned_arr.len(), 0);
+    assert!(cloned_arr.is_empty());
+
+    let empty_map = WafMap::new(0);
+    let cloned_map = empty_map.clone();
+    assert_eq!(cloned_map.len(), 0);
+    assert!(cloned_map.is_empty());
+}
+
+#[test]
+fn clone_array_shallow() {
+    let mut orig = WafArray::new(3);
+    orig[0] = 42u64.into();
+    orig[1] = "hello".into();
+    orig[2] = true.into();
+
+    let cloned = orig.clone();
+
+    // Verify values are equal
+    assert_eq!(orig[0].to_u64(), cloned[0].to_u64());
+    assert_eq!(orig[1].to_str(), cloned[1].to_str());
+    assert_eq!(orig[2].to_bool(), cloned[2].to_bool());
+
+    // Verify independence
+    drop(orig);
+    assert_eq!(cloned[0].to_u64(), Some(42));
+    assert_eq!(cloned[1].to_str(), Some("hello"));
+    assert_eq!(cloned[2].to_bool(), Some(true));
+}
+
+#[test]
+fn clone_array_deep() {
+    let mut orig = WafArray::new(3);
+    orig[0] = 42u64.into();
+    orig[1] = "hello".into();
+    orig[2] = waf_array!(1u64, 2u64).into();
+
+    let cloned = orig.clone();
+
+    drop(orig);
+    assert_eq!(cloned[0].to_u64(), Some(42));
+    assert_eq!(cloned[1].to_str(), Some("hello"));
+
+    let nested = cloned[2].as_type::<WafArray>().unwrap();
+    assert_eq!(nested.len(), 2);
+    assert_eq!(nested[0].to_u64(), Some(1));
+    assert_eq!(nested[1].to_u64(), Some(2));
+}
+
+#[test]
+fn clone_map_shallow() {
+    let orig = waf_map!(("key1", 42u64), ("key2", "hello"));
+    let cloned = orig.clone();
+
+    assert_eq!(cloned.get_str("key1").unwrap().to_u64(), Some(42));
+    assert_eq!(cloned.get_str("key2").unwrap().to_str(), Some("hello"));
+
+    drop(orig);
+    assert_eq!(cloned.get_str("key1").unwrap().to_u64(), Some(42));
+}
+
+#[test]
+fn clone_map_deep() {
+    let orig = waf_map!(("key1", 42u64), ("key2", waf_array!(1u64, 2u64)));
+    let cloned = orig.clone();
+
+    drop(orig);
+
+    assert_eq!(cloned.get_str("key1").unwrap().to_u64(), Some(42));
+    let nested_arr = cloned
+        .get_str("key2")
+        .unwrap()
+        .as_type::<WafArray>()
+        .unwrap();
+    assert_eq!(nested_arr.len(), 2);
+    assert_eq!(nested_arr[0].to_u64(), Some(1));
+    assert_eq!(nested_arr[1].to_u64(), Some(2));
+}
+
+#[test]
+fn clone_waf_object_dispatch() {
+    let objects = vec![
+        WafObject::from(42u64),
+        WafObject::from(-42i64),
+        WafObject::from(3.28),
+        WafObject::from(true),
+        WafObject::from("hello"),
+        WafObject::from(()),
+        WafObject::from(waf_array!(1u64)),
+        WafObject::from(waf_map!(("k", "v"))),
+    ];
+
+    for obj in objects {
+        let cloned = obj.clone();
+        assert_eq!(obj, cloned);
+        drop(obj);
+        assert!(cloned.is_valid());
+    }
+}
+
+#[test]
+fn clone_keyed() {
+    let orig: Keyed<WafObject> = ("key", 42u64).into();
+    let cloned = orig.clone();
+
+    assert_eq!(orig.key_str().unwrap(), cloned.key_str().unwrap());
+    assert_eq!(orig.value().to_u64(), cloned.value().to_u64());
+
+    drop(orig);
+    assert_eq!(cloned.key_str().unwrap(), "key");
+    assert_eq!(cloned.value().to_u64(), Some(42));
+}
+
+#[test]
+fn clone_complex_nested() {
+    let complex = waf_map!(
+        (
+            "users",
+            waf_array!(
+                waf_map!(("name", "Alice"), ("age", 30u64), ("active", true)),
+                waf_map!(("name", "Bob"), ("age", 25u64), ("active", false))
+            )
+        ),
+        ("metadata", waf_map!(("version", "1.0"), ("count", 2u64)))
+    );
+
+    let cloned = complex.clone();
+    drop(complex);
+
+    let users = cloned
+        .get_str("users")
+        .unwrap()
+        .as_type::<WafArray>()
+        .unwrap();
+    assert_eq!(users.len(), 2);
+
+    let alice = users[0].as_type::<WafMap>().unwrap();
+    assert_eq!(alice.get_str("name").unwrap().to_str(), Some("Alice"));
+    assert_eq!(alice.get_str("age").unwrap().to_u64(), Some(30));
+    assert_eq!(alice.get_str("active").unwrap().to_bool(), Some(true));
+
+    let bob = users[1].as_type::<WafMap>().unwrap();
+    assert_eq!(bob.get_str("name").unwrap().to_str(), Some("Bob"));
+
+    let metadata = cloned
+        .get_str("metadata")
+        .unwrap()
+        .as_type::<WafMap>()
+        .unwrap();
+    assert_eq!(metadata.get_str("version").unwrap().to_str(), Some("1.0"));
+    assert_eq!(metadata.get_str("count").unwrap().to_u64(), Some(2));
+}
+
+#[test]
+fn clone_memory_independence() {
+    let mut orig = waf_array!(1u64, 2u64, 3u64);
+    let cloned = orig.clone();
+
+    // Modify original
+    orig[0] = 999u64.into();
+
+    // Cloned should be unchanged
+    assert_eq!(cloned[0].to_u64(), Some(1));
+    assert_eq!(orig[0].to_u64(), Some(999));
+}
+
+#[test]
+fn clone_array_size_not_capacity() {
+    // Create array with capacity > size
+    let mut orig = WafArray::new(5);
+    orig[0] = 1u64.into();
+    orig[1] = 2u64.into();
+    orig.truncate(2);
+
+    let cloned = orig.clone();
+
+    // Cloned should have size == capacity == 2
+    assert_eq!(cloned.len(), 2);
+    assert_eq!(cloned[0].to_u64(), Some(1));
+    assert_eq!(cloned[1].to_u64(), Some(2));
+}
+
+#[test]
+fn clone_map_size_not_capacity() {
+    // Create map with capacity > size
+    let mut orig = WafMap::new(5);
+    orig[0] = ("key1", 1u64).into();
+    orig[1] = ("key2", 2u64).into();
+    orig.truncate(2);
+
+    assert_eq!(orig.capacity(), 5);
+
+    let cloned = orig.clone();
+
+    // Cloned should have size == capacity == 2
+    assert_eq!(cloned.len(), 2);
+    assert_eq!(cloned.capacity(), 2);
+    assert_eq!(cloned.get_str("key1").unwrap().to_u64(), Some(1));
+    assert_eq!(cloned.get_str("key2").unwrap().to_u64(), Some(2));
+}

--- a/crates/libddwaf/tests/common/mod.rs
+++ b/crates/libddwaf/tests/common/mod.rs
@@ -1,0 +1,69 @@
+#![allow(dead_code)]
+
+use std::sync::LazyLock;
+
+use libddwaf::object::WafMap;
+use libddwaf::{waf_array, waf_map};
+
+pub static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {
+    waf_map! {
+        ("version", "2.1"),
+        ("rules", waf_array![
+            waf_map!{
+                ("id", "arachni_rule"),
+                ("name", "Block with default action"),
+                ("tags", waf_map!{ ("category", "attack_attempt"), ("type", "security_scanner") }),
+                ("conditions", waf_array![
+                    waf_map!{
+                        ("operator", "match_regex"),
+                        ("parameters", waf_map!{
+                            ("inputs", waf_array![
+                                waf_map!{
+                                    ("address", "server.request.headers.no_cookies"),
+                                    ("key_path", waf_array!["user-agent"]),
+                                },
+                                waf_map!{
+                                    ("address", "server.request.body"),
+                                },
+                            ]),
+                            ("regex", "Arachni"),
+                        }),
+                    },
+                ]),
+                ("on_match", waf_array!["block"])
+            },
+        ]),
+    }
+});
+
+pub static PASSWORD_RULE: LazyLock<WafMap> = LazyLock::new(|| {
+    waf_map! {
+        ("version", "2.1"),
+        ("rules", waf_array![
+            waf_map!{
+                ("id", "password_rule"),
+                ("name", "Block with default action"),
+                ("tags", waf_map!{ ("category", "attack_attempt"), ("type", "security_scanner") }),
+                ("conditions", waf_array![
+                    waf_map!{
+                        ("operator", "match_regex"),
+                        ("parameters", waf_map!{
+                            ("inputs", waf_array![
+                                waf_map!{
+                                    ("address", "server.request.query"),
+                                    ("key_path", waf_array!["password"]),
+                                },
+                                waf_map!{
+                                    ("address", "server.request.query"),
+                                    ("key_path", waf_array!["p"]),
+                                }
+                            ]),
+                            ("regex", ".*"),
+                        }),
+                    },
+                ]),
+                ("on_match", waf_array!["block"])
+            },
+        ]),
+    }
+});

--- a/crates/libddwaf/tests/config.rs
+++ b/crates/libddwaf/tests/config.rs
@@ -1,5 +1,3 @@
-use std::ffi::CStr;
-
 use libddwaf::{OBFUSCATOR_DEFAULT_KEY_REGEX, OBFUSCATOR_DEFAULT_VAL_REGEX, Obfuscator};
 
 #[test]
@@ -15,8 +13,7 @@ pub fn key_only_obfuscator() {
     assert_eq!(
         obfuscator
             .key_regex()
-            .map(CStr::to_str)
-            .and_then(Result::ok),
+            .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
         Some(".*")
     );
     assert!(obfuscator.value_regex().is_none());
@@ -29,8 +26,7 @@ pub fn value_only_obfuscator() {
     assert_eq!(
         obfuscator
             .value_regex()
-            .map(CStr::to_str)
-            .and_then(Result::ok),
+            .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
         Some(".*")
     );
 }
@@ -45,15 +41,13 @@ pub fn clone_validity() {
     assert_eq!(
         obfuscator
             .key_regex()
-            .map(CStr::to_str)
-            .and_then(Result::ok),
+            .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
         Some(OBFUSCATOR_DEFAULT_KEY_REGEX)
     );
     assert_eq!(
         obfuscator
             .value_regex()
-            .map(CStr::to_str)
-            .and_then(Result::ok),
+            .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
         Some(OBFUSCATOR_DEFAULT_VAL_REGEX)
     );
 }

--- a/crates/libddwaf/tests/config.rs
+++ b/crates/libddwaf/tests/config.rs
@@ -1,13 +1,18 @@
-#![cfg(not(miri))]
+#[cfg(not(miri))]
+use std::time::Duration;
 
-use libddwaf::{OBFUSCATOR_DEFAULT_KEY_REGEX, OBFUSCATOR_DEFAULT_VAL_REGEX, Obfuscator};
+use libddwaf::Obfuscator;
 
-#[test]
-pub fn default_obfuscator() {
-    let obfuscator = Obfuscator::default();
-    assert!(obfuscator.key_regex().is_some());
-    assert!(obfuscator.value_regex().is_some());
-}
+#[cfg(not(miri))]
+use libddwaf::{
+    Config, RunResult, RunnableContext,
+    object::{WafArray, WafMap},
+};
+
+#[cfg(not(miri))]
+use crate::common::PASSWORD_RULE;
+
+mod common;
 
 #[test]
 pub fn key_only_obfuscator() {
@@ -37,19 +42,164 @@ pub fn value_only_obfuscator() {
 pub fn clone_validity() {
     let obfuscator = {
         // Clone from this and let it get dropped.
-        let def = Obfuscator::default();
+        let def = Obfuscator::new(Some("a"), Some("b"));
         def.clone()
     };
     assert_eq!(
         obfuscator
             .key_regex()
             .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
-        Some(OBFUSCATOR_DEFAULT_KEY_REGEX)
+        Some("a")
     );
     assert_eq!(
         obfuscator
             .value_regex()
             .map(|r| unsafe { std::str::from_utf8_unchecked(r) }),
-        Some(OBFUSCATOR_DEFAULT_VAL_REGEX)
+        Some("b")
     );
+}
+
+#[cfg(not(miri))]
+fn get_match_value(rr: &RunResult) -> &str {
+    match rr {
+        RunResult::Match(output) => {
+            let events = output.events().unwrap();
+
+            (events[0]
+                .as_type::<WafMap>()
+                .unwrap()
+                .get_str("rule_matches")
+                .unwrap()
+                .as_type::<WafArray>()
+                .unwrap()[0]
+                .as_type::<WafMap>()
+                .unwrap()
+                .get_str("parameters")
+                .unwrap()
+                .as_type::<WafArray>()
+                .unwrap()[0]
+                .as_type::<WafMap>()
+                .unwrap()
+                .get_str("value")
+                .unwrap()
+                .to_str()
+                .unwrap()) as _
+        }
+        _ => {
+            panic!("Unexpected result: {rr:?}");
+        }
+    }
+}
+
+#[test]
+#[cfg(not(miri))]
+fn default_uses_default_obfuscator() {
+    use libddwaf::{Builder, waf_map};
+
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
+    assert!(builder.add_or_update_config("rules", &*PASSWORD_RULE, None));
+    let waf = builder.build().unwrap();
+
+    let data = waf_map! {
+        ("server.request.query",
+        waf_map! {
+            ("password", "foobar"),
+        }),
+    };
+
+    let mut ctx = waf.new_context();
+    let res = ctx.run(data, Duration::from_secs(1)).unwrap();
+
+    let match_value = get_match_value(&res);
+    assert_eq!(match_value, "<Redacted>");
+}
+
+#[test]
+#[cfg(not(miri))]
+fn none_uses_no_obfuscator() {
+    use libddwaf::{Builder, waf_map};
+
+    let mut builder = Builder::new(None).expect("Failed to create builder");
+    assert!(builder.add_or_update_config("rules", &*PASSWORD_RULE, None));
+    let waf = builder.build().unwrap();
+
+    let data = waf_map! {
+        ("server.request.query",
+        waf_map! {
+            ("password", "foobar"),
+        }),
+    };
+
+    let mut ctx = waf.new_context();
+    let res = ctx.run(data, Duration::from_secs(1)).unwrap();
+
+    let match_value = get_match_value(&res);
+    assert_eq!(match_value, "foobar");
+}
+
+#[test]
+#[cfg(not(miri))]
+fn empty_values_use_effectively_no_obfuscator() {
+    use libddwaf::{Builder, waf_map};
+
+    let obfuscator = Obfuscator::new(Some(""), Some(""));
+    let mut builder =
+        Builder::new(Some(&Config::new(obfuscator))).expect("Failed to create builder");
+    assert!(builder.add_or_update_config("rules", &*PASSWORD_RULE, None));
+    let waf = builder.build().unwrap();
+
+    let data = waf_map! {
+        ("server.request.query",
+        waf_map! {
+            ("password", "foobar"),
+        }),
+    };
+
+    let mut ctx = waf.new_context();
+    let res = ctx.run(data, Duration::from_secs(1)).unwrap();
+
+    let match_value = get_match_value(&res);
+    assert_eq!(match_value, "foobar");
+}
+
+#[test]
+#[cfg(not(miri))]
+pub fn with_an_actual_obfuscator() {
+    use libddwaf::{Builder, waf_map};
+
+    let obfuscator = Obfuscator::new(Some(""), Some("bar"));
+    let mut builder =
+        Builder::new(Some(&Config::new(obfuscator))).expect("Failed to create builder");
+    assert!(builder.add_or_update_config(
+        "rules",
+        std::sync::LazyLock::force(&PASSWORD_RULE),
+        None
+    ));
+    let waf = builder.build().unwrap();
+
+    let data = waf_map! {
+        ("server.request.query",
+        waf_map! {
+            ("p", "foobar"),
+        }),
+    };
+
+    let mut ctx = waf.new_context();
+    let res = ctx.run(data, Duration::from_secs(1)).unwrap();
+
+    let match_value = get_match_value(&res);
+    assert_eq!(match_value, "<Redacted>");
+
+    let data = waf_map! {
+        ("server.request.query",
+        waf_map! {
+            ("p", "foobaz"),
+        }),
+    };
+
+    let mut ctx = waf.new_context();
+    let res = ctx.run(data, Duration::from_secs(1)).unwrap();
+
+    let match_value = get_match_value(&res);
+    assert_eq!(match_value, "foobaz");
 }

--- a/crates/libddwaf/tests/config.rs
+++ b/crates/libddwaf/tests/config.rs
@@ -5,8 +5,8 @@ use libddwaf::Obfuscator;
 
 #[cfg(not(miri))]
 use libddwaf::{
-    Config, RunResult, RunnableContext,
     object::{WafArray, WafMap},
+    Config, RunResult, RunnableContext,
 };
 
 #[cfg(not(miri))]
@@ -94,7 +94,7 @@ fn get_match_value(rr: &RunResult) -> &str {
 #[test]
 #[cfg(not(miri))]
 fn default_uses_default_obfuscator() {
-    use libddwaf::{Builder, waf_map};
+    use libddwaf::{waf_map, Builder};
 
     let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", &*PASSWORD_RULE, None));
@@ -117,7 +117,7 @@ fn default_uses_default_obfuscator() {
 #[test]
 #[cfg(not(miri))]
 fn none_uses_no_obfuscator() {
-    use libddwaf::{Builder, waf_map};
+    use libddwaf::{waf_map, Builder};
 
     let mut builder = Builder::new(None).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", &*PASSWORD_RULE, None));
@@ -140,7 +140,7 @@ fn none_uses_no_obfuscator() {
 #[test]
 #[cfg(not(miri))]
 fn empty_values_use_effectively_no_obfuscator() {
-    use libddwaf::{Builder, waf_map};
+    use libddwaf::{waf_map, Builder};
 
     let obfuscator = Obfuscator::new(Some(""), Some(""));
     let mut builder =
@@ -165,7 +165,7 @@ fn empty_values_use_effectively_no_obfuscator() {
 #[test]
 #[cfg(not(miri))]
 pub fn with_an_actual_obfuscator() {
-    use libddwaf::{Builder, waf_map};
+    use libddwaf::{waf_map, Builder};
 
     let obfuscator = Obfuscator::new(Some(""), Some("bar"));
     let mut builder =

--- a/crates/libddwaf/tests/config.rs
+++ b/crates/libddwaf/tests/config.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use libddwaf::{OBFUSCATOR_DEFAULT_KEY_REGEX, OBFUSCATOR_DEFAULT_VAL_REGEX, Obfuscator};
 
 #[test]

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -189,7 +189,7 @@ fn run_rule_threaded() {
                         let ctx = ctx.clone();
                         let data = data.clone();
                         std::thread::spawn(move || {
-                            let mut subctx = (*ctx).create_subcontext();
+                            let mut subctx = (*ctx).new_subcontext().unwrap();
 
                             let res = subctx.run(data, Duration::from_secs(1));
 

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -7,13 +7,10 @@
 )]
 
 use std::sync::LazyLock;
-use std::{
-    sync::{Arc, Mutex},
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use libddwaf::{
-    Builder, Config, RunResult,
+    Builder, Config, RunResult, RunnableContext,
     object::{WafArray, WafMap, WafObject, WafOwned},
     waf_array, waf_map,
 };
@@ -51,7 +48,7 @@ static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {
 
 #[test]
 fn basic_run_rule_with_match() {
-    let mut builder = Builder::new(&Config::default()).expect("Failed to create builder");
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     let mut diagnostics = WafOwned::<WafMap>::default();
     assert!(builder.add_or_update_config(
         "rules",
@@ -81,7 +78,7 @@ fn basic_run_rule_with_match() {
     let mut data = WafMap::new(1);
     data[0] = ("server.request.headers.no_cookies", header).into();
 
-    let res = ctx.run(Some(data), None, Duration::from_secs(1));
+    let res = ctx.run(data, Duration::from_secs(1));
 
     match res {
         Ok(RunResult::Match(result)) => {
@@ -100,7 +97,7 @@ fn basic_run_rule_with_match() {
 
             let actions = result.actions().expect("Expected some actions");
             assert_eq!(actions.len(), 1);
-            assert!(actions.get(b"block_request").is_some(),);
+            assert!(actions.get_bstr(b"block_request").is_some(),);
         }
         _ => {
             panic!("Unexpected result: {res:?}");
@@ -110,7 +107,7 @@ fn basic_run_rule_with_match() {
 
 #[test]
 fn basic_run_rule_with_no_match() {
-    let mut builder = Builder::new(&Config::default()).expect("Failed to create builder");
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     let mut diagnostics = WafOwned::<WafMap>::default();
     assert!(builder.add_or_update_config(
         "rules",
@@ -140,7 +137,7 @@ fn basic_run_rule_with_no_match() {
     let mut data = WafMap::new(1);
     data[0] = ("server.request.headers.no_cookies", header).into();
 
-    let res = ctx.run(Some(data), None, Duration::from_secs(1));
+    let res = ctx.run(data, Duration::from_secs(1));
 
     match res {
         Ok(RunResult::NoMatch(result)) => {
@@ -166,7 +163,7 @@ fn basic_run_rule_with_no_match() {
 
 #[test]
 fn run_rule_threaded() {
-    let mut builder = Builder::new(&Config::default()).expect("Failed to create builder");
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", LazyLock::force(&ARACHNI_RULE), None));
     let waf = Arc::new(builder.build().unwrap());
 
@@ -178,24 +175,26 @@ fn run_rule_threaded() {
         Into::<WafObject>::into(header),
     )
         .into();
-    let adata = Arc::new(data);
 
     let t: Vec<_> = (0..2)
         .map(|_| {
-            let data = adata.clone();
             let waf = waf.clone();
+            let data = data.clone();
             std::thread::spawn(move || {
-                let ctx = Arc::new(Mutex::new(waf.new_context()));
+                let ctx = Arc::new(waf.new_context());
 
                 (0..2)
                     .map(|_| {
+                        let ctx = ctx.clone();
                         let data = data.clone();
-                        let ctx = Arc::clone(&ctx);
                         std::thread::spawn(move || {
-                            let mut ctx = ctx.lock().unwrap();
+                            let mut subctx = (*ctx).create_subcontext();
 
-                            let res = ctx.run(None, Some(&data), Duration::from_secs(1));
+                            let res = subctx.run(data, Duration::from_secs(1));
 
+                            if !matches!(res, Ok(RunResult::Match(_))) {
+                                eprintln!("Unexpected result: {res:?}");
+                            }
                             assert!(matches!(res, Ok(RunResult::Match(_))));
                         })
                     })
@@ -207,4 +206,49 @@ fn run_rule_threaded() {
         .collect();
 
     t.into_iter().for_each(|t| t.join().unwrap());
+}
+
+#[test]
+fn test_run_error_display() {
+    use libddwaf::RunError;
+
+    assert_eq!(
+        format!("{}", RunError::InternalError),
+        "The WAF encountered an internal error"
+    );
+    assert_eq!(
+        format!("{}", RunError::InvalidObject),
+        "The WAF encountered an invalid object"
+    );
+    assert_eq!(
+        format!("{}", RunError::InvalidArgument),
+        "The WAF encountered an invalid argument"
+    );
+}
+
+#[test]
+fn test_run_output_debug() {
+    let mut builder = Builder::new(Some(&Config::default())).expect("builder should be created");
+    let mut diagnostics = WafOwned::<WafMap>::default();
+    assert!(builder.add_or_update_config("test", &*ARACHNI_RULE, Some(&mut diagnostics)));
+    let waf = builder.build().expect("waf should be created");
+
+    let mut ctx = waf.new_context();
+    let data = waf_map! {
+        ("server.request.headers.no_cookies", waf_map!{
+            ("user-agent", "Arachni"),
+        }),
+    };
+
+    match ctx.run(data, Duration::from_secs(1)) {
+        Ok(RunResult::Match(output)) => {
+            // Test that Debug formatting works
+            let debug_str = format!("{:?}", output);
+            assert!(debug_str.contains("RunOutput"));
+            assert!(debug_str.contains("timeout"));
+            assert!(debug_str.contains("keep"));
+            assert!(debug_str.contains("duration"));
+        }
+        other => panic!("Expected match result, got: {:?}", other),
+    }
 }

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 #![warn(
     clippy::correctness,
     clippy::pedantic,

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -178,7 +178,7 @@ fn run_rule_threaded() {
     )
         .into();
 
-    let t: Vec<_> = (0..2)
+    let threads: Vec<_> = (0..2)
         .map(|_| {
             let waf = waf.clone();
             let data = data.clone();
@@ -207,7 +207,9 @@ fn run_rule_threaded() {
         })
         .collect();
 
-    t.into_iter().for_each(|t| t.join().unwrap());
+    for t in threads {
+        t.join().unwrap();
+    }
 }
 
 #[test]
@@ -245,12 +247,12 @@ fn test_run_output_debug() {
     match ctx.run(data, Duration::from_secs(1)) {
         Ok(RunResult::Match(output)) => {
             // Test that Debug formatting works
-            let debug_str = format!("{:?}", output);
+            let debug_str = format!("{output:?}");
             assert!(debug_str.contains("RunOutput"));
             assert!(debug_str.contains("timeout"));
             assert!(debug_str.contains("keep"));
             assert!(debug_str.contains("duration"));
         }
-        other => panic!("Expected match result, got: {:?}", other),
+        other => panic!("Expected match result, got: {other:?}"),
     }
 }

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -10,9 +10,10 @@
 use std::sync::LazyLock;
 use std::{sync::Arc, time::Duration};
 
+use libddwaf::object::WafOwnedDefaultAllocator;
 use libddwaf::{
     Builder, Config, RunResult, RunnableContext,
-    object::{WafArray, WafMap, WafObject, WafOwned},
+    object::{WafArray, WafMap, WafObject},
     waf_array, waf_map,
 };
 
@@ -50,7 +51,7 @@ static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {
 #[test]
 fn basic_run_rule_with_match() {
     let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
-    let mut diagnostics = WafOwned::<WafMap>::default();
+    let mut diagnostics = WafOwnedDefaultAllocator::<WafMap>::default();
     assert!(builder.add_or_update_config(
         "rules",
         LazyLock::force(&ARACHNI_RULE),
@@ -109,7 +110,7 @@ fn basic_run_rule_with_match() {
 #[test]
 fn basic_run_rule_with_no_match() {
     let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
-    let mut diagnostics = WafOwned::<WafMap>::default();
+    let mut diagnostics = WafOwnedDefaultAllocator::<WafMap>::default();
     assert!(builder.add_or_update_config(
         "rules",
         LazyLock::force(&ARACHNI_RULE),
@@ -230,7 +231,7 @@ fn test_run_error_display() {
 #[test]
 fn test_run_output_debug() {
     let mut builder = Builder::new(Some(&Config::default())).expect("builder should be created");
-    let mut diagnostics = WafOwned::<WafMap>::default();
+    let mut diagnostics = WafOwnedDefaultAllocator::<WafMap>::default();
     assert!(builder.add_or_update_config("test", &*ARACHNI_RULE, Some(&mut diagnostics)));
     let waf = builder.build().expect("waf should be created");
 

--- a/crates/libddwaf/tests/context.rs
+++ b/crates/libddwaf/tests/context.rs
@@ -12,9 +12,8 @@ use std::{sync::Arc, time::Duration};
 
 use libddwaf::object::WafOwnedDefaultAllocator;
 use libddwaf::{
-    Builder, Config, RunResult, RunnableContext,
     object::{WafArray, WafMap, WafObject},
-    waf_array, waf_map,
+    waf_array, waf_map, Builder, Config, RunResult, RunnableContext,
 };
 
 static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {

--- a/crates/libddwaf/tests/handle.rs
+++ b/crates/libddwaf/tests/handle.rs
@@ -36,7 +36,7 @@ static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {
 
 #[test]
 fn test_known_actions() {
-    let mut builder = Builder::new(&Config::default()).expect("Failed to create builder");
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", std::sync::LazyLock::force(&ARACHNI_RULE), None));
     let waf = builder.build().unwrap();
 
@@ -48,7 +48,7 @@ fn test_known_actions() {
 
 #[test]
 fn test_known_addresses() {
-    let mut builder = Builder::new(&Config::default()).expect("Failed to create builder");
+    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", std::sync::LazyLock::force(&ARACHNI_RULE), None));
     let waf = builder.build().unwrap();
 

--- a/crates/libddwaf/tests/handle.rs
+++ b/crates/libddwaf/tests/handle.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::sync::LazyLock;
 
 use libddwaf::object::WafMap;

--- a/crates/libddwaf/tests/handle.rs
+++ b/crates/libddwaf/tests/handle.rs
@@ -1,44 +1,14 @@
 #![cfg(not(miri))]
 
-use std::sync::LazyLock;
+use libddwaf::Builder;
 
-use libddwaf::object::WafMap;
-use libddwaf::{Builder, Config, waf_array, waf_map};
+use common::ARACHNI_RULE;
 
-static ARACHNI_RULE: LazyLock<WafMap> = LazyLock::new(|| {
-    waf_map! {
-        ("version", "2.1"),
-        ("rules", waf_array![
-            waf_map!{
-                ("id", "arachni_rule"),
-                ("name", "Block with default action"),
-                ("tags", waf_map!{ ("category", "attack_attempt"), ("type", "security_scanner") }),
-                ("conditions", waf_array![
-                    waf_map!{
-                        ("operator", "match_regex"),
-                        ("parameters", waf_map!{
-                            ("inputs", waf_array![
-                                waf_map!{
-                                    ("address", "server.request.headers.no_cookies"),
-                                    ("key_path", waf_array!["user-agent"]),
-                                },
-                                waf_map!{
-                                    ("address", "server.request.body"),
-                                },
-                            ]),
-                            ("regex", "Arachni"),
-                        }),
-                    },
-                ]),
-                ("on_match", waf_array!["block"])
-            },
-        ]),
-    }
-});
+mod common;
 
 #[test]
 fn test_known_actions() {
-    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
+    let mut builder = Builder::new(None).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", std::sync::LazyLock::force(&ARACHNI_RULE), None));
     let waf = builder.build().unwrap();
 
@@ -50,7 +20,7 @@ fn test_known_actions() {
 
 #[test]
 fn test_known_addresses() {
-    let mut builder = Builder::new(Some(&Config::default())).expect("Failed to create builder");
+    let mut builder = Builder::new(None).expect("Failed to create builder");
     assert!(builder.add_or_update_config("rules", std::sync::LazyLock::force(&ARACHNI_RULE), None));
     let waf = builder.build().unwrap();
 

--- a/crates/libddwaf/tests/log.rs
+++ b/crates/libddwaf/tests/log.rs
@@ -21,3 +21,47 @@ fn test_log_callback() {
     unsafe { reset_log_cb() };
     assert_eq!(LOG_COUNT.load(Ordering::SeqCst), 1);
 }
+
+#[test]
+fn test_level_display() {
+    assert_eq!(format!("{}", Level::Trace), "TRACE");
+    assert_eq!(format!("{}", Level::Debug), "DEBUG");
+    assert_eq!(format!("{}", Level::Info), "INFO");
+    assert_eq!(format!("{}", Level::Warn), "WARN");
+    assert_eq!(format!("{}", Level::Error), "ERROR");
+    assert_eq!(format!("{}", Level::Off), "OFF");
+}
+
+#[test]
+fn test_level_try_from() {
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_TRACE).unwrap(),
+        Level::Trace
+    );
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_DEBUG).unwrap(),
+        Level::Debug
+    );
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_INFO).unwrap(),
+        Level::Info
+    );
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_WARN).unwrap(),
+        Level::Warn
+    );
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_ERROR).unwrap(),
+        Level::Error
+    );
+    assert_eq!(
+        Level::try_from(libddwaf_sys::DDWAF_LOG_OFF).unwrap(),
+        Level::Off
+    );
+
+    // Test unknown level
+    let result = Level::try_from(0xFF);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(format!("{}", err), "Unknown log level: 0xFF");
+}

--- a/crates/libddwaf/tests/log.rs
+++ b/crates/libddwaf/tests/log.rs
@@ -1,3 +1,5 @@
+#![cfg(not(miri))]
+
 use std::ffi::CStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/libddwaf/tests/object.rs
+++ b/crates/libddwaf/tests/object.rs
@@ -219,7 +219,7 @@ fn invalid_utf8() {
 fn empty_key() {
     let map = waf_map!(("", 42_u64));
     let empty_slice: &[u8] = &[];
-    assert_eq!(map[0].key_bstr().unwrap(), empty_slice);
+    assert_eq!(map[0].key_bytes().unwrap(), empty_slice);
 }
 
 #[test]
@@ -269,10 +269,10 @@ fn map_fetching_methods() {
     let mut map = waf_map!(("key1", 1u64), ("key2", 2u64),);
 
     // index
-    assert_eq!(map[0].key_bstr().unwrap(), b"key1");
+    assert_eq!(map[0].key_bytes().unwrap(), b"key1");
     // index mut
-    map[0].set_key_bstr(b"new key");
-    assert_eq!(map[0].key_bstr().unwrap(), b"new key");
+    map[0].set_key_bytes(b"new key");
+    assert_eq!(map[0].key_bytes().unwrap(), b"new key");
 
     // get
     assert_eq!(map.get_bstr(b"key2").unwrap().to_u64().unwrap(), 2);
@@ -299,7 +299,7 @@ fn map_fetching_methods() {
     assert!(map.get_mut(b"bad key").is_none());
 
     // get_str_mut
-    map.get_str_mut("key3").unwrap().set_key_bstr(b"key4");
+    map.get_str_mut("key3").unwrap().set_key_bytes(b"key4");
     assert_eq!(map.get_str("key4").unwrap().to_u64().unwrap(), 3);
 
     assert!(map.get_str_mut("bad key").is_none());

--- a/crates/libddwaf/tests/object.rs
+++ b/crates/libddwaf/tests/object.rs
@@ -5,7 +5,7 @@ use libddwaf::{object::*, waf_array, waf_map, waf_object};
 fn defaults() {
     let obj = WafObject::default();
     assert!(!obj.is_valid());
-    assert_eq!(obj.get_type(), WafObjectType::Invalid);
+    assert_eq!(obj.object_type(), WafObjectType::Invalid);
 
     let obj = WafSigned::default();
     assert!(obj.is_valid());
@@ -183,7 +183,7 @@ fn ddwaf_obj_from_conversions() {
     assert!(obj.to_bool().unwrap());
 
     let obj: WafObject = ().into();
-    assert_eq!(obj.get_type(), WafObjectType::Null);
+    assert_eq!(obj.object_type(), WafObjectType::Null);
 
     let obj: WafObject = "Hello, world!".into();
     assert_eq!(obj.to_str(), Some("Hello, world!"));
@@ -259,9 +259,13 @@ fn keyed_obj_methods() {
     assert_eq!(elem_cast.value().value(), 42u64);
 
     assert!(elem.as_type_mut::<WafBool>().is_none());
+
     let elem_cast = elem.as_type_mut::<WafUnsigned>().unwrap();
-    elem_cast.set_key_str("key 2");
-    assert_eq!(elem_cast.key_str().unwrap(), "key 2");
+    assert_eq!(elem_cast.value().value(), 42u64);
+
+    let key_mut = elem.key_mut();
+    let _ = std::mem::replace(key_mut, "key 2".into());
+    assert_eq!(elem.key_str().unwrap(), "key 2");
 }
 
 #[test]
@@ -271,7 +275,9 @@ fn map_fetching_methods() {
     // index
     assert_eq!(map[0].key_bytes().unwrap(), b"key1");
     // index mut
-    map[0].set_key_bytes(b"new key");
+    let key_mut = map[0].key_mut();
+    let new_key = WafString::from(b"new key");
+    let _ = std::mem::replace(key_mut, new_key.into());
     assert_eq!(map[0].key_bytes().unwrap(), b"new key");
 
     // get
@@ -290,7 +296,9 @@ fn map_fetching_methods() {
     );
 
     // get_mut
-    map.get_mut(b"key2").unwrap().set_key_str("key3");
+    let key_mut = map.get_mut(b"key2").unwrap().key_mut();
+    let new_key = WafString::from(b"key3");
+    let _ = std::mem::replace(key_mut, new_key.into());
     let entry_k3 = map.get_str_mut("key3").unwrap();
     let new_entry: Keyed<WafUnsigned> = ("key3", 3u64).into();
     let _ = std::mem::replace(entry_k3, new_entry.into());
@@ -299,7 +307,9 @@ fn map_fetching_methods() {
     assert!(map.get_mut(b"bad key").is_none());
 
     // get_str_mut
-    map.get_str_mut("key3").unwrap().set_key_bytes(b"key4");
+    let key_mut = map.get_str_mut("key3").unwrap().key_mut();
+    let new_key = WafString::from(b"key4");
+    let _ = std::mem::replace(key_mut, new_key.into());
     assert_eq!(map.get_str("key4").unwrap().to_u64().unwrap(), 3);
 
     assert!(map.get_str_mut("bad key").is_none());
@@ -314,7 +324,7 @@ fn array_iteration() {
             0 => assert_eq!(elem.to_u64().unwrap(), 1),
             1 => assert_eq!(elem.to_str().unwrap(), "foo"),
             2 => assert_eq!(elem.as_type::<WafArray>().unwrap().len(), 1),
-            3 => assert_eq!(elem.get_type(), WafObjectType::Null),
+            3 => assert_eq!(elem.object_type(), WafObjectType::Null),
             _ => unreachable!(),
         }
     }
@@ -328,7 +338,7 @@ fn array_iteration() {
                 let _ = std::mem::replace(elem, new_str.into());
             }
             2 => assert_eq!(elem.as_type::<WafArray>().unwrap().len(), 1),
-            3 => assert_eq!(elem.get_type(), WafObjectType::Null),
+            3 => assert_eq!(elem.object_type(), WafObjectType::Null),
             _ => unreachable!(),
         }
     }
@@ -339,7 +349,7 @@ fn array_iteration() {
             0 => assert_eq!(elem.to_u64().unwrap(), 1),
             1 => assert_eq!(elem.to_str().unwrap(), "bar"),
             2 => assert_eq!(elem.as_type::<WafArray>().unwrap().len(), 1),
-            3 => assert_eq!(elem.get_type(), WafObjectType::Null),
+            3 => assert_eq!(elem.object_type(), WafObjectType::Null),
             _ => unreachable!(),
         }
     }
@@ -370,7 +380,7 @@ fn map_iteration() {
             }
             3 => {
                 assert_eq!(elem.key_str().unwrap(), "key4");
-                assert_eq!(elem.get_type(), WafObjectType::Null);
+                assert_eq!(elem.object_type(), WafObjectType::Null);
             }
             _ => unreachable!(),
         }
@@ -409,14 +419,14 @@ fn map_iteration() {
 fn partial_iteration() {
     let arr = waf_array!(1u64, "foo");
     for elem in arr {
-        if elem.get_type() == WafObjectType::Unsigned {
+        if elem.object_type() == WafObjectType::Unsigned {
             break;
         }
     }
 
     let map = waf_map!(("key1", 1u64), ("key2", "foo"));
     for elem in map {
-        if elem.get_type() == WafObjectType::Unsigned {
+        if elem.object_type() == WafObjectType::Unsigned {
             break;
         }
     }
@@ -706,7 +716,7 @@ fn test_array_from_large_slice_truncates() {
     // After From<&mut [T]>, the first u16::MAX elements in the vec are taken (replaced with default)
     // The element at index 65535 (the excess one) should still exist
     assert_eq!(large_vec.len(), EXCESS_SIZE);
-    assert_eq!(large_vec[0].get_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[0].object_type(), WafObjectType::Invalid);
     assert_eq!(large_vec[65535].to_u64().unwrap(), 65535);
 }
 
@@ -751,8 +761,8 @@ fn test_map_from_large_slice_truncates() {
     assert_eq!(map.get_str("key65534").unwrap().to_u64().unwrap(), 65534);
 
     assert_eq!(large_vec.len(), EXCESS_SIZE);
-    assert_eq!(large_vec[0].0.get_type(), WafObjectType::Invalid);
-    assert_eq!(large_vec[0].1.get_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[0].0.object_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[0].1.object_type(), WafObjectType::Invalid);
     assert_eq!(large_vec[65535].0.to_str().unwrap(), "key65535");
     assert_eq!(large_vec[65535].1.to_u64().unwrap(), 65535);
 }

--- a/crates/libddwaf/tests/object.rs
+++ b/crates/libddwaf/tests/object.rs
@@ -122,7 +122,7 @@ fn sample_mixed_object() {
         \"key 1\"=WafString(\"value 1\"), \"key 2\"=\
         WafSigned(-2), \"key 3\"=WafUnsigned(2), \
         \"key 4\"=WafFloat(5.2), \"key 5\"=WafNull, \
-        \"key 6\"=WafBool(true), \"\"=WafInvalid}]"
+        \"key 6\"=WafBool(true), WafInvalid=WafInvalid}]"
     );
 }
 
@@ -219,7 +219,7 @@ fn invalid_utf8() {
 fn empty_key() {
     let map = waf_map!(("", 42_u64));
     let empty_slice: &[u8] = &[];
-    assert_eq!(map[0].key(), empty_slice);
+    assert_eq!(map[0].key_bstr().unwrap(), empty_slice);
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn keyed_obj_methods() {
     let elem = &mut map[0];
     assert!(elem.as_type::<WafBool>().is_none());
     let elem_cast = elem.as_type::<WafUnsigned>().unwrap();
-    assert_eq!(elem_cast.value(), 42u64);
+    assert_eq!(elem_cast.value().value(), 42u64);
 
     assert!(elem.as_type_mut::<WafBool>().is_none());
     let elem_cast = elem.as_type_mut::<WafUnsigned>().unwrap();
@@ -269,17 +269,25 @@ fn map_fetching_methods() {
     let mut map = waf_map!(("key1", 1u64), ("key2", 2u64),);
 
     // index
-    assert_eq!(map[0].key(), b"key1");
+    assert_eq!(map[0].key_bstr().unwrap(), b"key1");
     // index mut
-    map[0].set_key(b"new key");
-    assert_eq!(map[0].key(), b"new key");
+    map[0].set_key_bstr(b"new key");
+    assert_eq!(map[0].key_bstr().unwrap(), b"new key");
 
     // get
-    assert_eq!(map.get(b"key2").unwrap().to_u64().unwrap(), 2);
-    assert!(map.get(b"bad key").is_none());
+    assert_eq!(map.get_bstr(b"key2").unwrap().to_u64().unwrap(), 2);
+    assert!(map.get_bstr(b"bad key").is_none());
     // get_str
     assert_eq!(map.get_str("key2").unwrap().to_u64().unwrap(), 2);
     assert!(map.get_str("bad key").is_none());
+    // get
+    assert_eq!(
+        map.get(WafString::new_literal(&b"key2"[..]))
+            .unwrap()
+            .to_u64()
+            .unwrap(),
+        2
+    );
 
     // get_mut
     map.get_mut(b"key2").unwrap().set_key_str("key3");
@@ -291,7 +299,7 @@ fn map_fetching_methods() {
     assert!(map.get_mut(b"bad key").is_none());
 
     // get_str_mut
-    map.get_str_mut("key3").unwrap().set_key(b"key4");
+    map.get_str_mut("key3").unwrap().set_key_bstr(b"key4");
     assert_eq!(map.get_str("key4").unwrap().to_u64().unwrap(), 3);
 
     assert!(map.get_str_mut("bad key").is_none());
@@ -673,4 +681,95 @@ fn test_from_json() {
     assert!(WafObject::from_json("{").is_none());
     // Too large (but otherwise valid)
     assert!(WafObject::from_json(format!(r#""{}""#, "a".repeat(u32::MAX as usize + 1))).is_none());
+}
+
+#[test]
+fn test_array_from_large_slice_truncates() {
+    const EXCESS_SIZE: usize = u16::MAX as usize + 1;
+    let mut large_vec: Vec<WafObject> = (0..EXCESS_SIZE)
+        .map(|i| WafObject::from(i as u64))
+        .collect();
+
+    let array = WafArray::from(&mut large_vec[..]);
+
+    // Verify the array was truncated to u16::MAX
+    assert_eq!(array.len(), u16::MAX);
+    assert_eq!(array.capacity(), u16::MAX);
+
+    // Verify the elements in the array are correct
+    assert_eq!(array[0].to_u64().unwrap(), 0);
+    assert_eq!(array[100].to_u64().unwrap(), 100);
+    assert_eq!(array[65534].to_u64().unwrap(), 65534);
+
+    // After From<&mut [T]>, the first u16::MAX elements in the vec are taken (replaced with default)
+    // The element at index 65535 (the excess one) should still exist
+    assert_eq!(large_vec.len(), EXCESS_SIZE);
+    assert_eq!(large_vec[0].get_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[65535].to_u64().unwrap(), 65535);
+}
+
+#[test]
+fn test_array_from_large_array_truncates() {
+    const EXCESS_SIZE: usize = u16::MAX as usize + 1;
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024) // 32 MB stack
+        .spawn(|| {
+            let large_array: [WafObject; EXCESS_SIZE] = std::array::from_fn(|i| (i as u64).into());
+            let array = WafArray::from(large_array);
+
+            assert_eq!(array.len(), u16::MAX);
+            assert_eq!(array.capacity(), u16::MAX);
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+#[test]
+fn test_map_from_large_slice_truncates() {
+    const EXCESS_SIZE: usize = u16::MAX as usize + 1;
+    let mut large_vec: Vec<(WafObject, WafObject)> = (0..EXCESS_SIZE)
+        .map(|i| {
+            (
+                WafObject::from(format!("key{}", i).as_str()),
+                WafObject::from(i as u64),
+            )
+        })
+        .collect();
+
+    let map = WafMap::from(&mut large_vec[..]);
+
+    assert_eq!(map.len(), u16::MAX);
+    assert_eq!(map.capacity(), u16::MAX);
+
+    assert_eq!(map.get_str("key0").unwrap().to_u64().unwrap(), 0);
+    assert_eq!(map.get_str("key100").unwrap().to_u64().unwrap(), 100);
+    assert_eq!(map.get_str("key65534").unwrap().to_u64().unwrap(), 65534);
+
+    assert_eq!(large_vec.len(), EXCESS_SIZE);
+    assert_eq!(large_vec[0].0.get_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[0].1.get_type(), WafObjectType::Invalid);
+    assert_eq!(large_vec[65535].0.to_str().unwrap(), "key65535");
+    assert_eq!(large_vec[65535].1.to_u64().unwrap(), 65535);
+}
+
+#[test]
+fn test_map_from_large_array_truncates() {
+    const EXCESS_SIZE: usize = u16::MAX as usize + 1;
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024) // 32 MB stack
+        .spawn(|| {
+            let large_array: [(WafObject, WafObject); EXCESS_SIZE] = std::array::from_fn(|i| {
+                (
+                    WafObject::from(format!("key{}", i).as_str()),
+                    WafObject::from(i as u64),
+                )
+            });
+            let map = WafMap::from(large_array);
+            assert_eq!(map.len(), u16::MAX);
+            assert_eq!(map.capacity(), u16::MAX);
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }

--- a/crates/libddwaf/tests/object.rs
+++ b/crates/libddwaf/tests/object.rs
@@ -650,6 +650,7 @@ fn try_from_implementations() {
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_from_json() {
     assert_eq!(
         WafObject::from_json(
@@ -684,6 +685,7 @@ fn test_from_json() {
 }
 
 #[test]
+#[cfg(not(miri))] // takes too long
 fn test_array_from_large_slice_truncates() {
     const EXCESS_SIZE: usize = u16::MAX as usize + 1;
     let mut large_vec: Vec<WafObject> = (0..EXCESS_SIZE)
@@ -709,6 +711,7 @@ fn test_array_from_large_slice_truncates() {
 }
 
 #[test]
+#[cfg(not(miri))] // takes too long
 fn test_array_from_large_array_truncates() {
     const EXCESS_SIZE: usize = u16::MAX as usize + 1;
     std::thread::Builder::new()
@@ -726,6 +729,7 @@ fn test_array_from_large_array_truncates() {
 }
 
 #[test]
+#[cfg(not(miri))] // takes too long
 fn test_map_from_large_slice_truncates() {
     const EXCESS_SIZE: usize = u16::MAX as usize + 1;
     let mut large_vec: Vec<(WafObject, WafObject)> = (0..EXCESS_SIZE)
@@ -754,6 +758,7 @@ fn test_map_from_large_slice_truncates() {
 }
 
 #[test]
+#[cfg(not(miri))] // takes too long
 fn test_map_from_large_array_truncates() {
     const EXCESS_SIZE: usize = u16::MAX as usize + 1;
     std::thread::Builder::new()

--- a/crates/libddwaf/tests/serde.rs
+++ b/crates/libddwaf/tests/serde.rs
@@ -440,7 +440,7 @@ fn limits_visit_primitives_success_paths() {
     let mut deserializer = serde_json::Deserializer::from_str(json);
     let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
     assert!(!result.truncated);
-    assert_eq!(result.value.to_bool().unwrap(), false);
+    assert!(!result.value.to_bool().unwrap());
 
     // Test null (unit)
     let json = "null";

--- a/crates/libddwaf/tests/serde.rs
+++ b/crates/libddwaf/tests/serde.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "serde")]
 
 use libddwaf::{
-    object::{WafArray, WafMap, WafObject, WafObjectType},
+    object::{WafArray, WafMap, WafObject, WafObjectType, WafString},
+    serde::{Limits, deserialize_with_limits},
     waf_array, waf_map, waf_object,
 };
 use serde_json::from_str;
@@ -111,4 +112,484 @@ fn sample_json_serialization() {
 ]
 "#;
     assert_eq!(res, expected_string.trim());
+}
+
+// ============================================================================
+// Tests for deserialization with limits
+// ============================================================================
+
+#[test]
+fn limits_default_values() {
+    let limits = Limits::default();
+    assert_eq!(limits.max_string_length, 4096);
+    assert_eq!(limits.max_depth, 21);
+    assert_eq!(limits.max_elements, 2048);
+}
+
+#[test]
+fn limits_no_truncation_when_within_limits() {
+    let json = r#"{"key": "value", "number": 42}"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(!result.truncated);
+    let expected = waf_map!(("key", "value"), ("number", 42_u64));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_string_truncation() {
+    let json = r#"{"key": "this is a long string that should be truncated"}"#;
+    let limits = Limits {
+        max_string_length: 10,
+        max_depth: 10,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_map!(("key", "this is a "));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_string_truncation_utf8_boundary() {
+    // Test that string truncation respects UTF-8 character boundaries
+    // "日本語" = 9 bytes (3 bytes per character)
+    let json = r#""日本語test""#;
+    let limits = Limits {
+        max_string_length: 7,
+        max_depth: 10,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    // Should truncate to valid UTF-8 boundary: "日本" (6 bytes)
+    let expected = waf_object!("日本");
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_depth_exceeded() {
+    let json = r#"{"a": {"b": {"c": {"d": "deep"}}}}"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 2,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_map!(("a", waf_map!(("b", waf_object!(null)))));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_depth_zero() {
+    let json = r#"{"key": "value"}"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 0,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_object!(null);
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_elements_exceeded_in_array() {
+    let json = r#"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 5,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    // 5 elements: 1 for array + 4 values
+    let expected = waf_array!(1_u64, 2_u64, 3_u64, 4_u64);
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_elements_exceeded_in_map() {
+    let json = r#"{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 5,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    // 5 elements: 1 for map + 2 entries (key+value each)
+    let expected = waf_map!(("a", 1_u64), ("b", 2_u64));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_combined_depth_and_elements() {
+    let json = r#"{"level1": {"level2": [1, 2, 3, 4, 5]}}"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 3,
+        max_elements: 15,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(!result.truncated);
+    let expected = waf_map!((
+        "level1",
+        waf_map!(("level2", waf_array!(1_u64, 2_u64, 3_u64, 4_u64, 5_u64)))
+    ));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_siblings_preserved_when_nested_truncated() {
+    // When a nested structure hits depth limit, siblings should still be preserved
+    let json = r#"["before", {"a": {"b": {"c": "deep"}}}, "after"]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 3,
+        max_elements: 100,
+    }; // depth=3: array->map->map->null
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_array!(
+        "before",
+        waf_map!(("a", waf_map!(("b", waf_object!(null))))),
+        "after"
+    );
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_depth_exactly_at_limit() {
+    // 3 levels deep with depth=3 should work (array -> map -> map -> string)
+    let json = r#"[{"a": {"b": "value"}}]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 3,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(!result.truncated);
+    let expected = waf_array!(waf_map!(("a", waf_map!(("b", "value")))));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_depth_one_over_limit() {
+    // 4 levels deep with depth=3 should truncate deepest
+    let json = r#"[{"a": {"b": {"c": "value"}}}]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 3,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_array!(waf_map!(("a", waf_map!(("b", waf_object!(null))))));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn limits_nested_arrays_depth_truncated() {
+    let json = r#"[[1, 2], [3, 4], [5, 6]]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 1,
+        max_elements: 100,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    let expected = waf_array!(waf_object!(null), waf_object!(null), waf_object!(null));
+    assert_eq!(result.value, expected);
+}
+
+#[test]
+fn test_zero_element_limit() {
+    let json = r#"[1, 2, 3]"#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits);
+
+    // With 0 elements allowed, we can't even create the array
+    // This should still succeed but truncate everything
+    assert!(result.is_ok());
+    let res = result.unwrap();
+    assert!(res.truncated);
+    assert_eq!(res.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_i64_with_element_exhaustion() {
+    let json = "-42";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_f64_with_element_exhaustion() {
+    let json = "3.14";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_bool_with_element_exhaustion() {
+    let json = "true";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_unit_with_element_exhaustion() {
+    let json = "null";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_primitives_success_paths() {
+    // Test that primitive values are properly created when element limit allows
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 10,
+    };
+
+    // Test i64
+    let json = "-42";
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+    assert!(!result.truncated);
+    assert_eq!(result.value.to_i64().unwrap(), -42);
+
+    // Test f64
+    let json = "3.28";
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+    assert!(!result.truncated);
+    assert_eq!(result.value.to_f64().unwrap(), 3.28);
+
+    // Test bool
+    let json = "false";
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+    assert!(!result.truncated);
+    assert_eq!(result.value.to_bool().unwrap(), false);
+
+    // Test null (unit)
+    let json = "null";
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+    assert!(!result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_str_with_element_exhaustion() {
+    let json = r#""hello""#;
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn limits_visit_u64_with_element_exhaustion() {
+    let json = "42";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let result = deserialize_with_limits(&mut deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
+}
+
+#[test]
+fn test_visit_bytes_directly() {
+    // Test the basic Visitor's visit_bytes method by creating a custom deserializer
+    use serde::de::Visitor;
+
+    struct BytesDeserializer(&'static [u8]);
+
+    impl<'de> serde::Deserializer<'de> for BytesDeserializer {
+        type Error = serde::de::value::Error;
+
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_bytes(self.0)
+        }
+
+        serde::forward_to_deserialize_any! {
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bytes byte_buf option unit unit_struct newtype_struct seq tuple
+            tuple_struct map struct enum identifier ignored_any
+        }
+    }
+
+    // Test basic visitor
+    let bytes: &[u8] = b"test bytes";
+    let deserializer = BytesDeserializer(bytes);
+    let result: WafObject = serde::Deserialize::deserialize(deserializer).unwrap();
+    assert_eq!(result.to_str().unwrap(), "test bytes");
+}
+
+#[test]
+fn limits_visit_bytes_with_truncation() {
+    // Test LimitedVisitor's visit_bytes with truncation
+    use serde::de::Visitor;
+
+    struct BytesDeserializer(&'static [u8]);
+
+    impl<'de> serde::Deserializer<'de> for BytesDeserializer {
+        type Error = serde::de::value::Error;
+
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_bytes(self.0)
+        }
+
+        serde::forward_to_deserialize_any! {
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bytes byte_buf option unit unit_struct newtype_struct seq tuple
+            tuple_struct map struct enum identifier ignored_any
+        }
+    }
+
+    let bytes: &[u8] = b"This is a long byte string that should be truncated";
+    let limits = Limits {
+        max_string_length: 10,
+        max_depth: 10,
+        max_elements: 100,
+    };
+    let deserializer = BytesDeserializer(bytes);
+    let result = deserialize_with_limits(deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    // Should be truncated to 10 bytes
+    assert_eq!(
+        result
+            .value
+            .as_type::<WafString>()
+            .unwrap()
+            .as_bytes()
+            .len(),
+        10
+    );
+}
+
+#[test]
+fn limits_visit_bytes_with_element_exhaustion() {
+    // Test LimitedVisitor's visit_bytes with element exhaustion
+    use serde::de::Visitor;
+
+    struct BytesDeserializer(&'static [u8]);
+
+    impl<'de> serde::Deserializer<'de> for BytesDeserializer {
+        type Error = serde::de::value::Error;
+
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: Visitor<'de>,
+        {
+            visitor.visit_bytes(self.0)
+        }
+
+        serde::forward_to_deserialize_any! {
+            bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+            bytes byte_buf option unit unit_struct newtype_struct seq tuple
+            tuple_struct map struct enum identifier ignored_any
+        }
+    }
+
+    let bytes: &[u8] = b"test";
+    let limits = Limits {
+        max_string_length: 100,
+        max_depth: 10,
+        max_elements: 0,
+    };
+    let deserializer = BytesDeserializer(bytes);
+    let result = deserialize_with_limits(deserializer, &limits).unwrap();
+
+    assert!(result.truncated);
+    assert_eq!(result.value, waf_object!(null));
 }

--- a/crates/libddwaf/tests/serde.rs
+++ b/crates/libddwaf/tests/serde.rs
@@ -2,7 +2,7 @@
 
 use libddwaf::{
     object::{WafArray, WafMap, WafObject, WafObjectType, WafString},
-    serde::{Limits, deserialize_with_limits},
+    serde::{deserialize_with_limits, Limits},
     waf_array, waf_map, waf_object,
 };
 use serde_json::from_str;

--- a/crates/libddwaf/tests/serde.rs
+++ b/crates/libddwaf/tests/serde.rs
@@ -27,7 +27,7 @@ fn sample_json_deserialization() {
     // Test for null
     let json = "null";
     let ddwaf_obj: WafObject = from_str(json).expect("Failed to deserialize null");
-    assert_eq!(ddwaf_obj.get_type(), WafObjectType::Null);
+    assert_eq!(ddwaf_obj.object_type(), WafObjectType::Null);
 
     // Test for a string
     let json = "\"hello\"";


### PR DESCRIPTION
Prepare upgrade to v2, for when it's released.

Also:
* Reintroduces miri checks.
* With the removal of limits from ddwaf_run (now ddwaf_(sub)context_eval), it becomes even more necessary to apply limits when building the ddwaf objects. For this purpose, a new deserializer was implemented.